### PR TITLE
Move CorruptionException to snappy package

### DIFF
--- a/src/main/java/io/airlift/compress/snappy/CorruptionException.java
+++ b/src/main/java/io/airlift/compress/snappy/CorruptionException.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.airlift.compress;
+package io.airlift.compress.snappy;
 
 public class CorruptionException extends RuntimeException
 {

--- a/src/main/java/io/airlift/compress/snappy/Snappy.java
+++ b/src/main/java/io/airlift/compress/snappy/Snappy.java
@@ -17,8 +17,6 @@
  */
 package io.airlift.compress.snappy;
 
-import io.airlift.compress.CorruptionException;
-
 import java.util.Arrays;
 
 public final class Snappy

--- a/src/main/java/io/airlift/compress/snappy/SnappyDecompressor.java
+++ b/src/main/java/io/airlift/compress/snappy/SnappyDecompressor.java
@@ -17,8 +17,6 @@
  */
 package io.airlift.compress.snappy;
 
-import io.airlift.compress.CorruptionException;
-
 import static io.airlift.compress.snappy.SnappyInternalUtils.copyLong;
 import static io.airlift.compress.snappy.SnappyInternalUtils.loadByte;
 import static io.airlift.compress.snappy.SnappyInternalUtils.lookupShort;


### PR DESCRIPTION
To be replaced with MalformedInputException later