### PR TITLE
Load and instantiate test data sets once per VM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,18 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-core</artifactId>
             <scope>test</scope>

--- a/src/test/java/io/airlift/compress/TestingModule.java
+++ b/src/test/java/io/airlift/compress/TestingModule.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.compress;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Provides;
+import io.airlift.compress.benchmark.DataSet;
+import org.openjdk.jmh.annotations.Param;
+
+import javax.inject.Singleton;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TestingModule
+    implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+    }
+
+    @Provides
+    @Singleton
+    public List<DataSet> dataSets()
+            throws NoSuchFieldException, IOException
+    {
+        String[] testNames = DataSet.class
+                .getDeclaredField("name")
+                .getAnnotation(Param.class)
+                .value();
+
+        List<DataSet> result = new ArrayList<>();
+        for (String testName : testNames) {
+            DataSet entry = new DataSet(testName);
+            entry.setup();
+            result.add(entry);
+        }
+
+        return result;
+    }
+}

--- a/src/test/java/io/airlift/compress/benchmark/DataSet.java
+++ b/src/test/java/io/airlift/compress/benchmark/DataSet.java
@@ -87,8 +87,16 @@ public class DataSet
             "urls.10K",
     })
     private String name;
-
     private byte[] uncompressed;
+
+    public DataSet()
+    {
+    }
+
+    public DataSet(String name)
+    {
+        this.name = name;
+    }
 
     @Setup
     public void setup()
@@ -100,5 +108,10 @@ public class DataSet
     public byte[] getUncompressed()
     {
         return uncompressed;
+    }
+
+    public String getName()
+    {
+        return name;
     }
 }


### PR DESCRIPTION
They were being loaded once per test and TestNG was holding on to all instances
until the very end, which resulted in OOMs.