### PR TITLE
All Hadoop codec to be reset

### DIFF
--- a/src/main/java/io/airlift/compress/lz4/Lz4Codec.java
+++ b/src/main/java/io/airlift/compress/lz4/Lz4Codec.java
@@ -189,7 +189,6 @@ public class Lz4Codec
         @Override
         public void reset()
         {
-            throw new UnsupportedOperationException("LZ4 block compressor is not supported");
         }
 
         @Override
@@ -254,7 +253,6 @@ public class Lz4Codec
         @Override
         public void reset()
         {
-            throw new UnsupportedOperationException("LZ4 block decompressor is not supported");
         }
 
         @Override

--- a/src/main/java/io/airlift/compress/lzo/LzoCodec.java
+++ b/src/main/java/io/airlift/compress/lzo/LzoCodec.java
@@ -191,7 +191,6 @@ public class LzoCodec
         @Override
         public void reset()
         {
-            throw new UnsupportedOperationException("LZO block compressor is not supported");
         }
 
         @Override
@@ -256,7 +255,6 @@ public class LzoCodec
         @Override
         public void reset()
         {
-            throw new UnsupportedOperationException("LZO block decompressor is not supported");
         }
 
         @Override

--- a/src/main/java/io/airlift/compress/snappy/SnappyCodec.java
+++ b/src/main/java/io/airlift/compress/snappy/SnappyCodec.java
@@ -185,7 +185,6 @@ public class SnappyCodec
         @Override
         public void reset()
         {
-            throw new UnsupportedOperationException("Snappy block compressor is not supported");
         }
 
         @Override
@@ -248,7 +247,6 @@ public class SnappyCodec
         @Override
         public void reset()
         {
-            throw new UnsupportedOperationException("Snappy block decompressor is not supported");
         }
 
         @Override


### PR DESCRIPTION
Some Hadoop code will cache codec instances, and when the instance
is returned to the pool, the reset method is called. Aircompressor
codecs do not have internal state so the reset method does nothing.