### PR TITLE
Improve LZO & LZ4 compression performance for small inputs

### DIFF
--- a/src/main/java/io/airlift/compress/lz4/Lz4Compressor.java
+++ b/src/main/java/io/airlift/compress/lz4/Lz4Compressor.java
@@ -16,8 +16,8 @@ package io.airlift.compress.lz4;
 import io.airlift.compress.Compressor;
 
 import java.nio.ByteBuffer;
-import java.util.Arrays;
 
+import static io.airlift.compress.lz4.Lz4RawCompressor.MAX_TABLE_SIZE;
 import static io.airlift.compress.lz4.UnsafeUtil.getAddress;
 import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
 
@@ -27,7 +27,7 @@ import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
 public class Lz4Compressor
         implements Compressor
 {
-    private final int[] table = new int[Lz4RawCompressor.STREAM_SIZE];
+    private final int[] table = new int[MAX_TABLE_SIZE];
 
     @Override
     public int maxCompressedLength(int uncompressedSize)
@@ -38,8 +38,6 @@ public class Lz4Compressor
     @Override
     public int compress(byte[] input, int inputOffset, int inputLength, byte[] output, int outputOffset, int maxOutputLength)
     {
-        Arrays.fill(table, 0);
-
         long inputAddress = ARRAY_BYTE_BASE_OFFSET + inputOffset;
         long outputAddress = ARRAY_BYTE_BASE_OFFSET + outputOffset;
 
@@ -49,8 +47,6 @@ public class Lz4Compressor
     @Override
     public void compress(ByteBuffer input, ByteBuffer output)
     {
-        Arrays.fill(table, 0);
-
         Object inputBase;
         long inputAddress;
         long inputLimit;

--- a/src/main/java/io/airlift/compress/lz4/Lz4RawCompressor.java
+++ b/src/main/java/io/airlift/compress/lz4/Lz4RawCompressor.java
@@ -13,20 +13,6 @@
  */
 package io.airlift.compress.lz4;
 
-/*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
-
 import java.util.Arrays;
 
 import static io.airlift.compress.lz4.Lz4Constants.LAST_LITERAL_SIZE;

--- a/src/main/java/io/airlift/compress/lzo/LzoCompressor.java
+++ b/src/main/java/io/airlift/compress/lzo/LzoCompressor.java
@@ -16,8 +16,8 @@ package io.airlift.compress.lzo;
 import io.airlift.compress.Compressor;
 
 import java.nio.ByteBuffer;
-import java.util.Arrays;
 
+import static io.airlift.compress.lzo.LzoRawCompressor.MAX_TABLE_SIZE;
 import static io.airlift.compress.lzo.UnsafeUtil.getAddress;
 import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
 
@@ -27,7 +27,7 @@ import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
 public class LzoCompressor
     implements Compressor
 {
-    private final int[] table = new int[LzoRawCompressor.STREAM_SIZE];
+    private final int[] table = new int[MAX_TABLE_SIZE];
 
     @Override
     public int maxCompressedLength(int uncompressedSize)
@@ -38,8 +38,6 @@ public class LzoCompressor
     @Override
     public int compress(byte[] input, int inputOffset, int inputLength, byte[] output, int outputOffset, int maxOutputLength)
     {
-        Arrays.fill(table, 0);
-
         long inputAddress = ARRAY_BYTE_BASE_OFFSET + inputOffset;
         long outputAddress = ARRAY_BYTE_BASE_OFFSET + outputOffset;
 
@@ -49,8 +47,6 @@ public class LzoCompressor
     @Override
     public void compress(ByteBuffer input, ByteBuffer output)
     {
-        Arrays.fill(table, 0);
-
         Object inputBase;
         long inputAddress;
         long inputLimit;

--- a/src/main/java/io/airlift/compress/lzo/LzoRawCompressor.java
+++ b/src/main/java/io/airlift/compress/lzo/LzoRawCompressor.java
@@ -13,20 +13,6 @@
  */
 package io.airlift.compress.lzo;
 
-/*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
-
 import java.util.Arrays;
 
 import static io.airlift.compress.lzo.LzoConstants.SIZE_OF_INT;

--- a/src/main/java/io/airlift/compress/lzo/LzoRawCompressor.java
+++ b/src/main/java/io/airlift/compress/lzo/LzoRawCompressor.java
@@ -27,6 +27,8 @@ package io.airlift.compress.lzo;
 * limitations under the License.
 */
 
+import java.util.Arrays;
+
 import static io.airlift.compress.lzo.LzoConstants.SIZE_OF_INT;
 import static io.airlift.compress.lzo.LzoConstants.SIZE_OF_LONG;
 import static io.airlift.compress.lzo.LzoConstants.SIZE_OF_SHORT;
@@ -39,12 +41,11 @@ public final class LzoRawCompressor
 
     private static final int MAX_INPUT_SIZE = 0x7E000000;   /* 2 113 929 216 bytes */
 
-    private static final int MEMORY_USAGE = 14;
-    public static final int STREAM_SIZE = 2 * ((1 << (MEMORY_USAGE - 3)) + 4);
+    private static final int HASH_LOG = 12;
+    private static final int HASH_SHIFT = 40 - HASH_LOG;
 
-    private static final int HASHLOG = MEMORY_USAGE - 2;
-    private static final int HASH_SHIFT = 40 - HASHLOG;
-    private static final int HASH_MASK = (1 << HASHLOG) - 1;
+    private static final int MIN_TABLE_SIZE = 16;
+    public static final int MAX_TABLE_SIZE = (1 << HASH_LOG);
 
     private static final int COPY_LENGTH = 8;
     private static final int MATCH_FIND_LIMIT = COPY_LENGTH + MIN_MATCH;
@@ -61,9 +62,9 @@ public final class LzoRawCompressor
 
     private LzoRawCompressor() {}
 
-    private static int hash(long value)
+    private static int hash(long value, int mask)
     {
-        return (int) ((value * 889523592379L >>> HASH_SHIFT) & HASH_MASK);
+        return (int) ((value * 889523592379L >>> HASH_SHIFT) & mask);
     }
 
     public static int maxCompressedLength(int sourceLength)
@@ -80,6 +81,11 @@ public final class LzoRawCompressor
             final long maxOutputLength,
             final int[] table)
     {
+        int tableSize = computeTableSize(inputLength);
+        Arrays.fill(table, 0, tableSize, 0);
+
+        int mask = tableSize - 1;
+
         if (inputLength > MAX_INPUT_SIZE) {
             throw new IllegalArgumentException("Max input length exceeded");
         }
@@ -109,10 +115,10 @@ public final class LzoRawCompressor
 
         // First Byte
         // put position in hash
-        table[hash(UNSAFE.getLong(inputBase, input))] = (int) (input - inputAddress);
+        table[hash(UNSAFE.getLong(inputBase, input), mask)] = (int) (input - inputAddress);
 
         input++;
-        int nextHash = hash(UNSAFE.getLong(inputBase, input));
+        int nextHash = hash(UNSAFE.getLong(inputBase, input), mask);
 
         boolean done = false;
         boolean firstLiteral = true;
@@ -137,7 +143,7 @@ public final class LzoRawCompressor
 
                 // get position on hash
                 matchIndex = inputAddress + table[hash];
-                nextHash = hash(UNSAFE.getLong(inputBase, nextInputIndex));
+                nextHash = hash(UNSAFE.getLong(inputBase, nextInputIndex), mask);
 
                 // put position on hash
                 table[hash] = (int) (input - inputAddress);
@@ -175,16 +181,16 @@ public final class LzoRawCompressor
                 }
 
                 long position = input - 2;
-                table[hash(UNSAFE.getLong(inputBase, position))] = (int) (position - inputAddress);
+                table[hash(UNSAFE.getLong(inputBase, position), mask)] = (int) (position - inputAddress);
 
                 // Test next position
-                int hash = hash(UNSAFE.getLong(inputBase, input));
+                int hash = hash(UNSAFE.getLong(inputBase, input), mask);
                 matchIndex = inputAddress + table[hash];
                 table[hash] = (int) (input - inputAddress);
 
                 if (matchIndex + MAX_DISTANCE < input || UNSAFE.getInt(inputBase, matchIndex) != UNSAFE.getInt(inputBase, input)) {
                     input++;
-                    nextHash = hash(UNSAFE.getLong(inputBase, input));
+                    nextHash = hash(UNSAFE.getLong(inputBase, input), mask);
                     break;
                 }
 
@@ -376,5 +382,14 @@ public final class LzoRawCompressor
             UNSAFE.putByte(outputBase, output++, (byte) remaining);
         }
         return output;
+    }
+
+    private static int computeTableSize(int inputSize)
+    {
+        // smallest power of 2 larger than inputSize
+        int target = Integer.highestOneBit(inputSize - 1) << 1;
+
+        // keep it between MIN_TABLE_SIZE and MAX_TABLE_SIZE
+        return Math.max(Math.min(target, MAX_TABLE_SIZE), MIN_TABLE_SIZE);
     }
 }


### PR DESCRIPTION
Before:

```
  compress    airlift_lz4             silesia/dickens              6,366,945   253.2MB/s ±  8201.4kB/s ( 3.16%) (N = 30, α = 99.9%)
  compress    airlift_lz4             silesia/mozilla             26,435,667   411.5MB/s ±  8480.2kB/s ( 2.01%) (N = 30, α = 99.9%)
  compress    airlift_lz4             silesia/mr                   5,440,937   382.1MB/s ±    16.0MB/s ( 4.20%) (N = 30, α = 99.9%)
  compress    airlift_lz4             silesia/nci                  5,533,040   721.4MB/s ±    27.3MB/s ( 3.78%) (N = 30, α = 99.9%)
  compress    airlift_lz4             silesia/ooffice              4,338,918   318.9MB/s ±  9512.4kB/s ( 2.91%) (N = 30, α = 99.9%)
  compress    airlift_lz4             silesia/osdb                 5,256,666   355.4MB/s ±    10.3MB/s ( 2.89%) (N = 30, α = 99.9%)
  compress    airlift_lz4             silesia/reymont              3,181,387   263.9MB/s ±    12.2MB/s ( 4.64%) (N = 30, α = 99.9%)
  compress    airlift_lz4             silesia/samba                7,716,839   468.6MB/s ±  5566.9kB/s ( 1.16%) (N = 30, α = 99.9%)
  compress    airlift_lz4             silesia/sao                  6,790,273   305.6MB/s ±  7385.8kB/s ( 2.36%) (N = 30, α = 99.9%)
  compress    airlift_lz4             silesia/webster             19,914,645   300.8MB/s ±  6039.3kB/s ( 1.96%) (N = 30, α = 99.9%)
  compress    airlift_lz4             silesia/x-ray                8,390,195   841.3MB/s ±    23.9MB/s ( 2.85%) (N = 30, α = 99.9%)
  compress    airlift_lz4             silesia/xml                  1,227,495   542.7MB/s ±    14.5MB/s ( 2.67%) (N = 30, α = 99.9%)
  compress    airlift_lz4             artificial/a.txt                     2  2989.2kB/s ±    42.8kB/s ( 1.43%) (N = 30, α = 99.9%)   <<<<
  compress    airlift_lz4             artificial/aaa.txt                 403  9504.0MB/s ±   151.1MB/s ( 1.59%) (N = 30, α = 99.9%)   <<<<
  compress    airlift_lz4             artificial/alphabet.txt            428  6448.3MB/s ±   902.0MB/s (13.99%) (N = 30, α = 99.9%)   <<<<
  compress    airlift_lz4             artificial/random.txt          100,394  6510.8MB/s ±    71.6MB/s ( 1.10%) (N = 30, α = 99.9%)
  compress    airlift_lzo             silesia/dickens              6,314,662   202.4MB/s ±  6809.6kB/s ( 3.29%) (N = 30, α = 99.9%)
  compress    airlift_lzo             silesia/mozilla             25,511,913   363.1MB/s ±  6992.1kB/s ( 1.88%) (N = 30, α = 99.9%)
  compress    airlift_lzo             silesia/mr                   5,315,507   337.9MB/s ±  5134.6kB/s ( 1.48%) (N = 30, α = 99.9%)
  compress    airlift_lzo             silesia/nci                  5,601,480   657.1MB/s ±    15.1MB/s ( 2.30%) (N = 30, α = 99.9%)
  compress    airlift_lzo             silesia/ooffice              4,297,083   268.2MB/s ±    11.2MB/s ( 4.18%) (N = 30, α = 99.9%)
  compress    airlift_lzo             silesia/osdb                 5,283,504   290.9MB/s ±    13.2MB/s ( 4.54%) (N = 30, α = 99.9%)
  compress    airlift_lzo             silesia/reymont              2,914,188   237.1MB/s ±  3061.9kB/s ( 1.26%) (N = 30, α = 99.9%)
  compress    airlift_lzo             silesia/samba                7,516,074   385.7MB/s ±  7699.1kB/s ( 1.95%) (N = 30, α = 99.9%)
  compress    airlift_lzo             silesia/sao                  6,838,540   241.4MB/s ±  7452.2kB/s ( 3.01%) (N = 30, α = 99.9%)
  compress    airlift_lzo             silesia/webster             19,624,249   232.8MB/s ±  2861.9kB/s ( 1.20%) (N = 30, α = 99.9%)
  compress    airlift_lzo             silesia/x-ray                8,439,172  1053.4MB/s ±    14.6MB/s ( 1.38%) (N = 30, α = 99.9%)
  compress    airlift_lzo             silesia/xml                  1,183,751   477.5MB/s ±  5129.5kB/s ( 1.05%) (N = 30, α = 99.9%)
  compress    airlift_lzo             artificial/a.txt                     5  2958.3kB/s ±    43.7kB/s ( 1.48%) (N = 30, α = 99.9%)   <<<<
  compress    airlift_lzo             artificial/aaa.txt                 407  8214.3MB/s ±   126.1MB/s ( 1.53%) (N = 30, α = 99.9%)   <<<<
  compress    airlift_lzo             artificial/alphabet.txt            431  8539.4MB/s ±   137.1MB/s ( 1.61%) (N = 30, α = 99.9%)   <<<<
  compress    airlift_lzo             artificial/random.txt          100,397  6479.1MB/s ±   105.4MB/s ( 1.63%) (N = 30, α = 99.9%)
```

After:

```
  compress    airlift_lz4             silesia/dickens              6,366,945   253.4MB/s ±  6348.6kB/s ( 2.45%) (N = 30, α = 99.9%)
  compress    airlift_lz4             silesia/mozilla             26,435,667   412.3MB/s ±  6368.2kB/s ( 1.51%) (N = 30, α = 99.9%)
  compress    airlift_lz4             silesia/mr                   5,440,937   383.4MB/s ±  8135.1kB/s ( 2.07%) (N = 30, α = 99.9%)
  compress    airlift_lz4             silesia/nci                  5,533,040   723.5MB/s ±    13.6MB/s ( 1.87%) (N = 30, α = 99.9%)
  compress    airlift_lz4             silesia/ooffice              4,338,918   311.9MB/s ±    10.4MB/s ( 3.35%) (N = 30, α = 99.9%)
  compress    airlift_lz4             silesia/osdb                 5,256,666   349.0MB/s ±  6630.0kB/s ( 1.86%) (N = 30, α = 99.9%)
  compress    airlift_lz4             silesia/reymont              3,181,387   270.9MB/s ±  4325.0kB/s ( 1.56%) (N = 30, α = 99.9%)
  compress    airlift_lz4             silesia/samba                7,716,839   459.6MB/s ±  9480.0kB/s ( 2.01%) (N = 30, α = 99.9%)
  compress    airlift_lz4             silesia/sao                  6,790,273   349.0MB/s ±  4073.5kB/s ( 1.14%) (N = 30, α = 99.9%)
  compress    airlift_lz4             silesia/webster             19,914,645   287.8MB/s ±  5932.8kB/s ( 2.01%) (N = 30, α = 99.9%)
  compress    airlift_lz4             silesia/x-ray                8,390,195   899.1MB/s ±    29.6MB/s ( 3.29%) (N = 30, α = 99.9%)
  compress    airlift_lz4             silesia/xml                  1,227,495   574.5MB/s ±    13.1MB/s ( 2.28%) (N = 30, α = 99.9%)
  compress    airlift_lz4             artificial/a.txt                     2    44.9MB/s ±   940.2kB/s ( 2.05%) (N = 30, α = 99.9%)   <<<<
  compress    airlift_lz4             artificial/aaa.txt                 403    10.1GB/s ±   257.0MB/s ( 2.49%) (N = 30, α = 99.9%)   <<<<
  compress    airlift_lz4             artificial/alphabet.txt            428  8034.7MB/s ±   181.7MB/s ( 2.26%) (N = 30, α = 99.9%)   <<<<
  compress    airlift_lz4             artificial/random.txt          100,394  6421.4MB/s ±   133.1MB/s ( 2.07%) (N = 30, α = 99.9%)
  compress    airlift_lzo             silesia/dickens              6,314,662   216.1MB/s ±  6087.4kB/s ( 2.75%) (N = 30, α = 99.9%)
  compress    airlift_lzo             silesia/mozilla             25,511,913   384.4MB/s ±  9779.0kB/s ( 2.48%) (N = 30, α = 99.9%)
  compress    airlift_lzo             silesia/mr                   5,315,507   365.3MB/s ±  7847.8kB/s ( 2.10%) (N = 30, α = 99.9%)
  compress    airlift_lzo             silesia/nci                  5,601,480   686.1MB/s ±    15.9MB/s ( 2.32%) (N = 30, α = 99.9%)
  compress    airlift_lzo             silesia/ooffice              4,297,083   256.2MB/s ±  6793.8kB/s ( 2.59%) (N = 30, α = 99.9%)
  compress    airlift_lzo             silesia/osdb                 5,283,504   286.2MB/s ±  5743.7kB/s ( 1.96%) (N = 30, α = 99.9%)
  compress    airlift_lzo             silesia/reymont              2,914,188   250.4MB/s ±  6051.6kB/s ( 2.36%) (N = 30, α = 99.9%)
  compress    airlift_lzo             silesia/samba                7,516,074   407.7MB/s ±  9798.2kB/s ( 2.35%) (N = 30, α = 99.9%)
  compress    airlift_lzo             silesia/sao                  6,838,540   264.1MB/s ±  5046.5kB/s ( 1.87%) (N = 30, α = 99.9%)
  compress    airlift_lzo             silesia/webster             19,624,249   239.6MB/s ±  4530.6kB/s ( 1.85%) (N = 30, α = 99.9%)
  compress    airlift_lzo             silesia/x-ray                8,439,172  1116.7MB/s ±    32.2MB/s ( 2.88%) (N = 30, α = 99.9%)
  compress    airlift_lzo             silesia/xml                  1,183,751   506.9MB/s ±  9431.5kB/s ( 1.82%) (N = 30, α = 99.9%)
  compress    airlift_lzo             artificial/a.txt                     5    44.9MB/s ±  1083.7kB/s ( 2.36%) (N = 30, α = 99.9%)   <<<<
  compress    airlift_lzo             artificial/aaa.txt                 407  8955.3MB/s ±   231.3MB/s ( 2.58%) (N = 30, α = 99.9%)   <<<<
  compress    airlift_lzo             artificial/alphabet.txt            431  9271.0MB/s ±   239.0MB/s ( 2.58%) (N = 30, α = 99.9%)   <<<<
  compress    airlift_lzo             artificial/random.txt          100,397  6777.7MB/s ±   152.6MB/s ( 2.25%) (N = 30, α = 99.9%)
```