### PR TITLE
Snappy without Unsafe

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>io.airlift</groupId>
-    <artifactId>aircompressor</artifactId>
+    <artifactId>aircompressor-safe</artifactId>
     <version>0.5-SNAPSHOT</version>
     <packaging>jar</packaging>
 

--- a/src/main/java/io/airlift/compress/snappy/SnappyDecompressor.java
+++ b/src/main/java/io/airlift/compress/snappy/SnappyDecompressor.java
@@ -26,10 +26,7 @@ public class SnappyDecompressor
 {
     public static int getUncompressedLength(byte[] compressed, int compressedOffset)
     {
-        long compressedAddress = ARRAY_BYTE_BASE_OFFSET + compressedOffset;
-        long compressedLimit = ARRAY_BYTE_BASE_OFFSET + compressed.length;
-
-        return SnappyRawDecompressor.getUncompressedLength(compressed, compressedAddress, compressedLimit);
+        return SnappyRawDecompressor.readUncompressedLength(compressed, compressedOffset, compressed.length)[0];
     }
 
     @Override

--- a/src/main/java/io/airlift/compress/snappy/SnappyDecompressor.java
+++ b/src/main/java/io/airlift/compress/snappy/SnappyDecompressor.java
@@ -36,12 +36,7 @@ public class SnappyDecompressor
     public int decompress(byte[] input, int inputOffset, int inputLength, byte[] output, int outputOffset, int maxOutputLength)
             throws MalformedInputException
     {
-        long inputAddress = ARRAY_BYTE_BASE_OFFSET + inputOffset;
-        long inputLimit = inputAddress + inputLength;
-        long outputAddress = ARRAY_BYTE_BASE_OFFSET + outputOffset;
-        long outputLimit = outputAddress + maxOutputLength;
-
-        return SnappyRawDecompressor.decompress(input, inputAddress, inputLimit, output, outputAddress, outputLimit);
+        return SnappyRawDecompressor.decompressSafe(input, inputOffset, inputOffset + inputLength, output, outputOffset, outputOffset + maxOutputLength);
     }
 
     @Override


### PR DESCRIPTION
I needed a pure-Java Snappy decompressor for a project deployed to App Engine standard environment. sun.misc.unsafe is off-limits in App Engine standard, so I tweaked aircompressor's Snappy support to avoid it. I cut a number of performance optimizations in doing so which adds to the performance hit this version would incur over the unsafe flavor.

I doubt this change is aligned with the performance goals for aircompressor but I thought having a record of the PR might save someone else effort in the future. Feel free to close if I'm right about that.