### PR TITLE
fix bug in input stream single byte read methods

### DIFF
--- a/src/main/java/io/airlift/compress/lz4/HadoopLz4InputStream.java
+++ b/src/main/java/io/airlift/compress/lz4/HadoopLz4InputStream.java
@@ -54,7 +54,7 @@ class HadoopLz4InputStream
             }
             uncompressedChunkLength = decompressor.decompress(compressed, 0, compressedChunkLength, uncompressedChunk, 0, uncompressedChunk.length);
         }
-        return uncompressedChunk[uncompressedChunkOffset--] & 0xFF;
+        return uncompressedChunk[uncompressedChunkOffset++] & 0xFF;
     }
 
     @Override

--- a/src/main/java/io/airlift/compress/lzo/HadoopLzoInputStream.java
+++ b/src/main/java/io/airlift/compress/lzo/HadoopLzoInputStream.java
@@ -54,7 +54,7 @@ class HadoopLzoInputStream
             }
             uncompressedChunkLength = decompressor.decompress(compressed, 0, compressedChunkLength, uncompressedChunk, 0, uncompressedChunk.length);
         }
-        return uncompressedChunk[uncompressedChunkOffset--] & 0xFF;
+        return uncompressedChunk[uncompressedChunkOffset++] & 0xFF;
     }
 
     @Override

--- a/src/main/java/io/airlift/compress/lzo/HadoopLzopInputStream.java
+++ b/src/main/java/io/airlift/compress/lzo/HadoopLzopInputStream.java
@@ -134,7 +134,7 @@ class HadoopLzopInputStream
 
             decompress(compressedLength, uncompressedChunk, 0, uncompressedChunk.length);
         }
-        return uncompressedChunk[uncompressedOffset--] & 0xFF;
+        return uncompressedChunk[uncompressedOffset++] & 0xFF;
     }
 
     @Override

--- a/src/main/java/io/airlift/compress/snappy/HadoopSnappyInputStream.java
+++ b/src/main/java/io/airlift/compress/snappy/HadoopSnappyInputStream.java
@@ -51,7 +51,7 @@ class HadoopSnappyInputStream
                 return -1;
             }
         }
-        return uncompressedChunk[uncompressedChunkOffset--] & 0xFF;
+        return uncompressedChunk[uncompressedChunkOffset++] & 0xFF;
     }
 
     @Override

--- a/src/test/java/io/airlift/compress/HadoopCodecDecompressor.java
+++ b/src/test/java/io/airlift/compress/HadoopCodecDecompressor.java
@@ -38,11 +38,21 @@ public class HadoopCodecDecompressor
         try (InputStream in = codec.createInputStream(new ByteArrayInputStream(input, inputOffset, inputLength))) {
             int bytesRead = 0;
             while (bytesRead < maxOutputLength) {
-                int size = in.read(output, outputOffset + bytesRead, maxOutputLength - bytesRead);
-                if (size < 0) {
-                    break;
+                if (bytesRead % 7 == 0) { // exercise both read APIs
+                    int result = in.read();
+                    if (result < 0) {
+                        break;
+                    }
+                    output[outputOffset + bytesRead] = (byte) (result & 0xff);
+                    bytesRead += 1;
                 }
-                bytesRead += size;
+                else {
+                    int size = in.read(output, outputOffset + bytesRead, maxOutputLength - bytesRead);
+                    if (size < 0) {
+                        break;
+                    }
+                    bytesRead += size;
+                }
             }
 
             if (in.read() >= 0) {


### PR DESCRIPTION
Input streams had a bug in the single byte read methods

Fixed and modified the existing unit tests to cover. Verified that the unit tests failed without the fix, and pass with it.