### PR TITLE
Allow overriding benchmark parameters from command line

### DIFF
--- a/src/test/java/io/airlift/compress/benchmark/CompressionBenchmark.java
+++ b/src/test/java/io/airlift/compress/benchmark/CompressionBenchmark.java
@@ -28,6 +28,8 @@ import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.results.RunResult;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.CommandLineOptionException;
+import org.openjdk.jmh.runner.options.CommandLineOptions;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.util.Statistics;
@@ -110,9 +112,10 @@ public class CompressionBenchmark
     }
 
     public static void main(String[] args)
-            throws RunnerException
+            throws RunnerException, CommandLineOptionException
     {
         Options opt = new OptionsBuilder()
+                .parent(new CommandLineOptions(args))
                 .include(".*\\." + CompressionBenchmark.class.getSimpleName() + ".*")
                 .build();
 


### PR DESCRIPTION
With this, it is possible to run a benchmark for a specific dataset or algorithm via:

```
mvn exec:exec \
    -Dexec.classpathScope=test \
    -Dexec.executable="java" \
    -Dexec.args="-cp %classpath io.airlift.compress.benchmark.CompressionBenchmark -p name=XXXX -p algorithm=YYYY"
```