### PR TITLE
Fix LZO compressor/decompressor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ jdk:
 
 sudo: false
 
+script:
+  - travis_wait 20 mvn test
+
 cache:
   directories:
     - $HOME/.m2/repository

--- a/src/main/java/io/airlift/compress/lzo/LzoRawCompressor.java
+++ b/src/main/java/io/airlift/compress/lzo/LzoRawCompressor.java
@@ -245,11 +245,11 @@ public final class LzoRawCompressor
         output += literalLength;
 
         // write stop command
+        // this is a 0b0001_HMMM command with a zero match offset
         UNSAFE.putByte(outputBase, output++, (byte) 0b0001_0001);
-
-        // write 2 zeros
         UNSAFE.putShort(outputBase, output, (byte) 0);
         output += SIZE_OF_SHORT;
+
         return output;
     }
 

--- a/src/main/java/io/airlift/compress/lzo/LzoRawDecompressor.java
+++ b/src/main/java/io/airlift/compress/lzo/LzoRawDecompressor.java
@@ -45,314 +45,303 @@ public final class LzoRawDecompressor
         // maximum offset in buffers to which it's safe to write long-at-a-time
         final long fastOutputLimit = outputLimit - SIZE_OF_LONG;
 
-        // LZO can concat two blocks together so, decode until the input data is consumed
         long input = inputAddress;
         long output = outputAddress;
-        while (input < inputLimit) {
-            //
-            // Note: For safety some of the code below may stop decoding early or skip decoding,
-            // because input is not available.  This makes the code safe, and since LZO requires
-            // an explicit "stop" command, the decoder will still throw a exception.
-            //
 
-            boolean firstCommand = true;
-            int lastLiteralLength = 0;
-            while (true) {
-                if (input >= inputLimit) {
-                    throw new MalformedInputException(input - inputAddress);
-                }
-                int command = UNSAFE.getByte(inputBase, input++) & 0xFF;
-                if (command == 0b0001_0001) {
-                    break;
-                }
+        boolean firstCommand = true;
+        int lastLiteralLength = 0;
+        while (true) {
+            if (input >= inputLimit) {
+                throw new MalformedInputException(input - inputAddress);
+            }
+            int command = UNSAFE.getByte(inputBase, input++) & 0xFF;
 
-                // Commands are described using a bit pattern notation:
-                // 0: bit is not set
-                // 1: bit is set
-                // L: part of literal length
-                // P: part of match offset position
-                // M: part of match length
-                // ?: see documentation in command decoder
+            // Commands are described using a bit pattern notation:
+            // 0: bit is not set
+            // 1: bit is set
+            // L: part of literal length
+            // H: high bits of match offset position
+            // D: low bits of match offset position
+            // M: part of match length
+            // ?: see documentation in command decoder
 
-                int matchLength;
-                int matchOffset;
-                int literalLength;
-                if ((command & 0b1111_0000) == 0b0000_0000) {
-                    if (lastLiteralLength == 0) {
-                        // 0b0000_LLLL (0bLLLL_LLLL)*
+            int matchLength;
+            int matchOffset;
+            int literalLength;
+            if ((command & 0b1111_0000) == 0b0000_0000) {
+                if (lastLiteralLength == 0) {
+                    // 0b0000_LLLL (0bLLLL_LLLL)*
+                    // copy 4 ore more literals only
 
-                        // copy length :: fixed
-                        //   0
-                        matchOffset = 0;
-
-                        // copy offset :: fixed
-                        //   0
-                        matchLength = 0;
-
-                        // literal length - 3 :: variable bits :: valid range [4..]
-                        //   3 + variableLength(command bits [0..3], 4)
-                        literalLength = command & 0b1111;
-                        if (literalLength == 0) {
-                            literalLength = 0b1111;
-
-                            int nextByte = 0;
-                            while (input < inputLimit && (nextByte = UNSAFE.getByte(inputBase, input++) & 0xFF) == 0) {
-                                literalLength += 0b1111_1111;
-                            }
-                            literalLength += nextByte;
-                        }
-                        literalLength += 3;
-                    }
-                    else if (lastLiteralLength <= 3) {
-                        // 0b0000_PPLL 0bPPPP_PPPP
-
-                        // copy length: fixed
-                        //   3
-                        matchLength = 3;
-
-                        // copy offset :: 12 bits :: valid range [2048..3071]
-                        //   [0..1] from command [2..3]
-                        //   [2..9] from trailer [0..7]
-                        //   [10] unset
-                        //   [11] set
-                        if (input >= inputLimit) {
-                            throw new MalformedInputException(input - inputAddress);
-                        }
-                        matchOffset = (command & 0b1100) >>> 2;
-                        matchOffset |= (UNSAFE.getByte(inputBase, input++) & 0xFF) << 2;
-                        matchOffset |= 0b1000_0000_0000;
-
-                        // literal length :: 2 bits :: valid range [0..3]
-                        //   [0..1] from command [0..1]
-                        literalLength = (command & 0b0000_0011);
-                    }
-                    else {
-                        // 0b0000_PPLL 0bPPPP_PPPP
-
-                        // copy length :: fixed
-                        //   2
-                        matchLength = 2;
-
-                        // copy offset :: 10 bits :: valid range [0..1023]
-                        //   [0..1] from command [2..3]
-                        //   [2..9] from trailer [0..7]
-                        if (input >= inputLimit) {
-                            throw new MalformedInputException(input - inputAddress);
-                        }
-                        matchOffset = (command & 0b1100) >>> 2;
-                        matchOffset |= (UNSAFE.getByte(inputBase, input++) & 0xFF) << 2;
-
-                        // literal length :: 2 bits :: valid range [0..3]
-                        //   [0..1] from command [0..1]
-                        literalLength = (command & 0b0000_0011);
-                    }
-                }
-                else if (firstCommand) {
-                    // first command has special handling when high nibble is set
-                    matchLength = 0;
+                    // copy length :: fixed
+                    //   0
                     matchOffset = 0;
-                    literalLength = command - 17;
-                }
-                else if ((command & 0b1111_0000) == 0b0001_0000) {
-                    // 0b0001_?MMM (0bMMMM_MMMM)* 0bPPPP_PPPP_PPPP_PPLL
 
-                    // copy length - 2 :: variable bits :: valid range [3..]
-                    //   2 + variableLength(command bits [0..2], 3)
-                    matchLength = command & 0b111;
-                    if (matchLength == 0) {
-                        matchLength = 0b111;
+                    // copy offset :: fixed
+                    //   0
+                    matchLength = 0;
 
-                        int nextByte = 0;
-                        while (input < inputLimit && (nextByte = UNSAFE.getByte(inputBase, input++) & 0xFF) == 0) {
-                            matchLength += 0b1111_1111;
-                        }
-                        matchLength += nextByte;
-                    }
-                    matchLength += 2;
-
-                    // read trailer
-                    if (input + SIZE_OF_SHORT > inputLimit) {
-                        throw new MalformedInputException(input - inputAddress);
-                    }
-                    int trailer = UNSAFE.getShort(inputBase, input) & 0xFFFF;
-                    input += SIZE_OF_SHORT;
-
-                    // copy offset :: 16 bits :: valid range [32767..49151]
-                    //   [0..13] from trailer [2..15]
-                    //   [14] if command bit [3] unset
-                    //   [15] if command bit [3] set
-                    matchOffset = trailer >> 2;
-                    if ((command & 0b1000) == 0) {
-                        matchOffset |= 0b0100_0000_0000_0000;
-                    }
-                    else {
-                        matchOffset |= 0b1000_0000_0000_0000;
-                    }
-                    matchOffset--;
-
-                    // literal length :: 2 bits :: valid range [0..3]
-                    //   [0..1] from trailer [0..1]
-                    literalLength = trailer & 0b11;
-                }
-                else if ((command & 0b1110_0000) == 0b0010_0000) {
-                    // 0b001M_MMMM (0bMMMM_MMMM)* 0bPPPP_PPPP_PPPP_PPLL
-
-                    // copy length - 2 :: variable bits :: valid range [3..]
-                    //   2 + variableLength(command bits [0..4], 5)
-                    matchLength = command & 0b1_1111;
-                    if (matchLength == 0) {
-                        matchLength = 0b1_1111;
+                    // literal length - 3 :: variable bits :: valid range [4..]
+                    //   3 + variableLength(command bits [0..3], 4)
+                    literalLength = command & 0b1111;
+                    if (literalLength == 0) {
+                        literalLength = 0b1111;
 
                         int nextByte = 0;
                         while (input < inputLimit && (nextByte = UNSAFE.getByte(inputBase, input++) & 0xFF) == 0) {
-                            matchLength += 0b1111_1111;
+                            literalLength += 0b1111_1111;
                         }
-                        matchLength += nextByte;
+                        literalLength += nextByte;
                     }
-                    matchLength += 2;
-
-                    // read trailer
-                    if (input + SIZE_OF_SHORT > inputLimit) {
-                        throw new MalformedInputException(input - inputAddress);
-                    }
-                    int trailer = UNSAFE.getShort(inputBase, input) & 0xFFFF;
-                    input += SIZE_OF_SHORT;
-
-                    // copy offset :: 14 bits :: valid range [0..16383]
-                    //  [0..13] from trailer [2..15]
-                    matchOffset = trailer >>> 2;
-
-                    // literal length :: 2 bits :: valid range [0..3]
-                    //   [0..1] from trailer [0..1]
-                    literalLength = trailer & 0b11;
+                    literalLength += 3;
                 }
-                else if ((command & 0b1100_0000) != 0) {
-                    // 0bMMMP_PPLL 0bPPPP_PPPP
+                else if (lastLiteralLength <= 3) {
+                    // 0b0000_DDLL 0bHHHH_HHHH
+                    // copy of a 2-byte block from the dictionary within a 1kB distance
 
-                    // copy length - 1 :: 3 bits :: valid range [1..8]
-                    //   [0..2] from command [5..7]
-                    //   add 1
-                    matchLength = (command & 0b1110_0000) >>> 5;
-                    matchLength += 1;
+                    // copy length: fixed
+                    //   2
+                    matchLength = 2;
 
-                    // copy offset :: 11 bits :: valid range [0..4095]
-                    //   [0..2] from command [2..4]
-                    //   [3..10] from trailer [0..7]
+                    // copy offset :: valid range [1..1024]
+                    //   DD from command [2..3]
+                    //   HH from trailer [0..7]
+                    // offset = (HH << 2) + DD + 1
                     if (input >= inputLimit) {
                         throw new MalformedInputException(input - inputAddress);
                     }
-                    matchOffset = (command & 0b0001_1100) >>> 2;
-                    matchOffset |= (UNSAFE.getByte(inputBase, input++) & 0xFF) << 3;
+                    matchOffset = (command & 0b1100) >>> 2;
+                    matchOffset |= (UNSAFE.getByte(inputBase, input++) & 0xFF) << 2;
 
                     // literal length :: 2 bits :: valid range [0..3]
                     //   [0..1] from command [0..1]
                     literalLength = (command & 0b0000_0011);
                 }
                 else {
-                    String binary = toBinary(command);
-                    throw new MalformedInputException(input - 1, "Invalid LZO command " + binary);
-                }
-                firstCommand = false;
+                    // 0b0000_DDLL 0bHHHH_HHHH
 
-                // copy match
-                if (matchLength != 0) {
-                    // lzo encodes match offset minus one
-                    matchOffset++;
+                    // copy length :: fixed
+                    //   3
+                    matchLength = 3;
 
-                    long matchAddress = output - matchOffset;
-                    if (matchAddress < outputAddress || output + matchLength > outputLimit) {
+                    // copy offset :: 10 bits :: valid range [2049..3072]
+                    //   DD from command [2..3]
+                    //   HH from trailer [0..7]
+                    // offset = (H << 2) + D + 2049
+                    if (input >= inputLimit) {
                         throw new MalformedInputException(input - inputAddress);
                     }
-                    long matchOutputLimit = output + matchLength;
+                    matchOffset = (command & 0b1100) >>> 2;
+                    matchOffset |= (UNSAFE.getByte(inputBase, input++) & 0xFF) << 2;
+                    matchOffset += 0b1000_0000_0000;
 
-                    if (output > fastOutputLimit) {
-                        // slow match copy
-                        while (output < matchOutputLimit) {
-                            UNSAFE.putByte(outputBase, output++, UNSAFE.getByte(outputBase, matchAddress++));
-                        }
+                    // literal length :: 2 bits :: valid range [0..3]
+                    //   [0..1] from command [0..1]
+                    literalLength = (command & 0b0000_0011);
+                }
+            }
+            else if (firstCommand) {
+                // first command has special handling when high nibble is set
+                matchLength = 0;
+                matchOffset = 0;
+                literalLength = command - 17;
+            }
+            else if ((command & 0b1111_0000) == 0b0001_0000) {
+                // 0b0001_?MMM (0bMMMM_MMMM)* 0bPPPP_PPPP_PPPP_PPLL
+
+                // copy length - 2 :: variable bits :: valid range [3..]
+                //   2 + variableLength(command bits [0..2], 3)
+                matchLength = command & 0b111;
+                if (matchLength == 0) {
+                    matchLength = 0b111;
+
+                    int nextByte = 0;
+                    while (input < inputLimit && (nextByte = UNSAFE.getByte(inputBase, input++) & 0xFF) == 0) {
+                        matchLength += 0b1111_1111;
+                    }
+                    matchLength += nextByte;
+                }
+                matchLength += 2;
+
+                // read trailer
+                if (input + SIZE_OF_SHORT > inputLimit) {
+                    throw new MalformedInputException(input - inputAddress);
+                }
+                int trailer = UNSAFE.getShort(inputBase, input) & 0xFFFF;
+                input += SIZE_OF_SHORT;
+
+                // copy offset :: 16 bits :: valid range [16383..49151]
+                //   [0..13] from trailer [2..15]
+                //   [14] if command bit [3] set
+                //   plus fixed offset 0b11_1111_1111_1111
+                matchOffset = (command & 0b1000) << 11;
+                matchOffset += trailer >> 2;
+                if (matchOffset == 0) {
+                    break;
+                }
+                matchOffset += 0b11_1111_1111_1111;
+
+                // literal length :: 2 bits :: valid range [0..3]
+                //   [0..1] from trailer [0..1]
+                literalLength = trailer & 0b11;
+            }
+            else if ((command & 0b1110_0000) == 0b0010_0000) {
+                // command in [32, 63]
+                // 0b001M_MMMM (0bMMMM_MMMM)* 0bPPPP_PPPP_PPPP_PPLL
+
+                // copy length - 2 :: variable bits :: valid range [3..]
+                //   2 + variableLength(command bits [0..4], 5)
+                matchLength = command & 0b1_1111;
+                if (matchLength == 0) {
+                    matchLength = 0b1_1111;
+
+                    int nextByte = 0;
+                    while (input < inputLimit && (nextByte = UNSAFE.getByte(inputBase, input++) & 0xFF) == 0) {
+                        matchLength += 0b1111_1111;
+                    }
+                    matchLength += nextByte;
+                }
+                matchLength += 2;
+
+                // read trailer
+                if (input + SIZE_OF_SHORT > inputLimit) {
+                    throw new MalformedInputException(input - inputAddress);
+                }
+                int trailer = UNSAFE.getShort(inputBase, input) & 0xFFFF;
+                input += SIZE_OF_SHORT;
+
+                // copy offset :: 14 bits :: valid range [0..16383]
+                //  [0..13] from trailer [2..15]
+                matchOffset = trailer >>> 2;
+
+                // literal length :: 2 bits :: valid range [0..3]
+                //   [0..1] from trailer [0..1]
+                literalLength = trailer & 0b11;
+            }
+            else if ((command & 0b1100_0000) != 0) {
+                // 0bMMMP_PPLL 0bPPPP_PPPP
+
+                // copy length - 1 :: 3 bits :: valid range [1..8]
+                //   [0..2] from command [5..7]
+                //   add 1
+                matchLength = (command & 0b1110_0000) >>> 5;
+                matchLength += 1;
+
+                // copy offset :: 11 bits :: valid range [0..4095]
+                //   [0..2] from command [2..4]
+                //   [3..10] from trailer [0..7]
+                if (input >= inputLimit) {
+                    throw new MalformedInputException(input - inputAddress);
+                }
+                matchOffset = (command & 0b0001_1100) >>> 2;
+                matchOffset |= (UNSAFE.getByte(inputBase, input++) & 0xFF) << 3;
+
+                // literal length :: 2 bits :: valid range [0..3]
+                //   [0..1] from command [0..1]
+                literalLength = (command & 0b0000_0011);
+            }
+            else {
+                String binary = toBinary(command);
+                throw new MalformedInputException(input - 1, "Invalid LZO command " + binary);
+            }
+            firstCommand = false;
+
+            // copy match
+            if (matchLength != 0) {
+                // lzo encodes match offset minus one
+                matchOffset++;
+
+                long matchAddress = output - matchOffset;
+                if (matchAddress < outputAddress || output + matchLength > outputLimit) {
+                    throw new MalformedInputException(input - inputAddress);
+                }
+                long matchOutputLimit = output + matchLength;
+
+                if (output > fastOutputLimit) {
+                    // slow match copy
+                    while (output < matchOutputLimit) {
+                        UNSAFE.putByte(outputBase, output++, UNSAFE.getByte(outputBase, matchAddress++));
+                    }
+                }
+                else {
+                    // copy repeated sequence
+                    if (matchOffset < SIZE_OF_LONG) {
+                        // 8 bytes apart so that we can copy long-at-a-time below
+                        int increment32 = DEC_32_TABLE[matchOffset];
+                        int decrement64 = DEC_64_TABLE[matchOffset];
+
+                        UNSAFE.putByte(outputBase, output, UNSAFE.getByte(outputBase, matchAddress));
+                        UNSAFE.putByte(outputBase, output + 1, UNSAFE.getByte(outputBase, matchAddress + 1));
+                        UNSAFE.putByte(outputBase, output + 2, UNSAFE.getByte(outputBase, matchAddress + 2));
+                        UNSAFE.putByte(outputBase, output + 3, UNSAFE.getByte(outputBase, matchAddress + 3));
+                        output += SIZE_OF_INT;
+                        matchAddress += increment32;
+
+                        UNSAFE.putInt(outputBase, output, UNSAFE.getInt(outputBase, matchAddress));
+                        output += SIZE_OF_INT;
+                        matchAddress -= decrement64;
                     }
                     else {
-                        // copy repeated sequence
-                        if (matchOffset < SIZE_OF_LONG) {
-                            // 8 bytes apart so that we can copy long-at-a-time below
-                            int increment32 = DEC_32_TABLE[matchOffset];
-                            int decrement64 = DEC_64_TABLE[matchOffset];
+                        UNSAFE.putLong(outputBase, output, UNSAFE.getLong(outputBase, matchAddress));
+                        matchAddress += SIZE_OF_LONG;
+                        output += SIZE_OF_LONG;
+                    }
 
-                            UNSAFE.putByte(outputBase, output, UNSAFE.getByte(outputBase, matchAddress));
-                            UNSAFE.putByte(outputBase, output + 1, UNSAFE.getByte(outputBase, matchAddress + 1));
-                            UNSAFE.putByte(outputBase, output + 2, UNSAFE.getByte(outputBase, matchAddress + 2));
-                            UNSAFE.putByte(outputBase, output + 3, UNSAFE.getByte(outputBase, matchAddress + 3));
-                            output += SIZE_OF_INT;
-                            matchAddress += increment32;
-
-                            UNSAFE.putInt(outputBase, output, UNSAFE.getInt(outputBase, matchAddress));
-                            output += SIZE_OF_INT;
-                            matchAddress -= decrement64;
+                    if (matchOutputLimit >= fastOutputLimit) {
+                        if (matchOutputLimit > outputLimit) {
+                            throw new MalformedInputException(input - inputAddress);
                         }
-                        else {
+
+                        while (output < fastOutputLimit) {
                             UNSAFE.putLong(outputBase, output, UNSAFE.getLong(outputBase, matchAddress));
                             matchAddress += SIZE_OF_LONG;
                             output += SIZE_OF_LONG;
                         }
 
-                        if (matchOutputLimit >= fastOutputLimit) {
-                            if (matchOutputLimit > outputLimit) {
-                                throw new MalformedInputException(input - inputAddress);
-                            }
-
-                            while (output < fastOutputLimit) {
-                                UNSAFE.putLong(outputBase, output, UNSAFE.getLong(outputBase, matchAddress));
-                                matchAddress += SIZE_OF_LONG;
-                                output += SIZE_OF_LONG;
-                            }
-
-                            while (output < matchOutputLimit) {
-                                UNSAFE.putByte(outputBase, output++, UNSAFE.getByte(outputBase, matchAddress++));
-                            }
-                        }
-                        else {
-                            while (output < matchOutputLimit) {
-                                UNSAFE.putLong(outputBase, output, UNSAFE.getLong(outputBase, matchAddress));
-                                matchAddress += SIZE_OF_LONG;
-                                output += SIZE_OF_LONG;
-                            }
+                        while (output < matchOutputLimit) {
+                            UNSAFE.putByte(outputBase, output++, UNSAFE.getByte(outputBase, matchAddress++));
                         }
                     }
-                    output = matchOutputLimit; // correction in case we over-copied
-                }
-
-                // copy literal
-                long literalOutputLimit = output + literalLength;
-                if (literalOutputLimit > fastOutputLimit || input + literalLength > inputLimit - SIZE_OF_LONG) {
-                    if (literalOutputLimit > outputLimit) {
-                        throw new MalformedInputException(input - inputAddress);
+                    else {
+                        while (output < matchOutputLimit) {
+                            UNSAFE.putLong(outputBase, output, UNSAFE.getLong(outputBase, matchAddress));
+                            matchAddress += SIZE_OF_LONG;
+                            output += SIZE_OF_LONG;
+                        }
                     }
-
-                    // slow, precise copy
-                    UNSAFE.copyMemory(inputBase, input, outputBase, output, literalLength);
-                    input += literalLength;
-                    output += literalLength;
                 }
-                else {
-                    // fast copy. We may over-copy but there's enough room in input and output to not overrun them
-                    do {
-                        UNSAFE.putLong(outputBase, output, UNSAFE.getLong(inputBase, input));
-                        input += SIZE_OF_LONG;
-                        output += SIZE_OF_LONG;
-                    }
-                    while (output < literalOutputLimit);
-                    input -= (output - literalOutputLimit); // adjust index if we over-copied
-                    output = literalOutputLimit;
-                }
-                lastLiteralLength = literalLength;
+                output = matchOutputLimit; // correction in case we over-copied
             }
 
-            if (input + SIZE_OF_SHORT > inputLimit && UNSAFE.getShort(inputBase, input) != 0) {
-                throw new MalformedInputException(input - inputAddress);
+            // copy literal
+            long literalOutputLimit = output + literalLength;
+            if (literalOutputLimit > fastOutputLimit || input + literalLength > inputLimit - SIZE_OF_LONG) {
+                if (literalOutputLimit > outputLimit) {
+                    throw new MalformedInputException(input - inputAddress);
+                }
+
+                // slow, precise copy
+                UNSAFE.copyMemory(inputBase, input, outputBase, output, literalLength);
+                input += literalLength;
+                output += literalLength;
             }
-            input += SIZE_OF_SHORT;
+            else {
+                // fast copy. We may over-copy but there's enough room in input and output to not overrun them
+                do {
+                    UNSAFE.putLong(outputBase, output, UNSAFE.getLong(inputBase, input));
+                    input += SIZE_OF_LONG;
+                    output += SIZE_OF_LONG;
+                }
+                while (output < literalOutputLimit);
+                input -= (output - literalOutputLimit); // adjust index if we over-copied
+                output = literalOutputLimit;
+            }
+            lastLiteralLength = literalLength;
         }
 
+        if (input != inputLimit) {
+            throw new MalformedInputException(input - inputAddress);
+        }
         return (int) (output - outputAddress);
     }
 

--- a/src/main/java/io/airlift/compress/lzo/LzoRawDecompressor.java
+++ b/src/main/java/io/airlift/compress/lzo/LzoRawDecompressor.java
@@ -71,7 +71,7 @@ public final class LzoRawDecompressor
             if ((command & 0b1111_0000) == 0b0000_0000) {
                 if (lastLiteralLength == 0) {
                     // 0b0000_LLLL (0bLLLL_LLLL)*
-                    // copy 4 ore more literals only
+                    // copy 4 or more literals only
 
                     // copy length :: fixed
                     //   0
@@ -133,7 +133,7 @@ public final class LzoRawDecompressor
                     }
                     matchOffset = (command & 0b1100) >>> 2;
                     matchOffset |= (UNSAFE.getByte(inputBase, input++) & 0xFF) << 2;
-                    matchOffset += 0b1000_0000_0000;
+                    matchOffset |= 0b1000_0000_0000;
 
                     // literal length :: 2 bits :: valid range [0..3]
                     //   [0..1] from command [0..1]
@@ -147,7 +147,7 @@ public final class LzoRawDecompressor
                 literalLength = command - 17;
             }
             else if ((command & 0b1111_0000) == 0b0001_0000) {
-                // 0b0001_?MMM (0bMMMM_MMMM)* 0bPPPP_PPPP_PPPP_PPLL
+                // 0b0001_HMMM (0bMMMM_MMMM)* 0bDDDD_DDDD_DDDD_DDLL
 
                 // copy length - 2 :: variable bits :: valid range [3..]
                 //   2 + variableLength(command bits [0..2], 3)
@@ -187,7 +187,7 @@ public final class LzoRawDecompressor
             }
             else if ((command & 0b1110_0000) == 0b0010_0000) {
                 // command in [32, 63]
-                // 0b001M_MMMM (0bMMMM_MMMM)* 0bPPPP_PPPP_PPPP_PPLL
+                // 0b001M_MMMM (0bMMMM_MMMM)* 0bDDDD_DDDD_DDDD_DDLL
 
                 // copy length - 2 :: variable bits :: valid range [3..]
                 //   2 + variableLength(command bits [0..4], 5)
@@ -219,7 +219,7 @@ public final class LzoRawDecompressor
                 literalLength = trailer & 0b11;
             }
             else if ((command & 0b1100_0000) != 0) {
-                // 0bMMMP_PPLL 0bPPPP_PPPP
+                // 0bMMMD_DDLL 0bHHHH_HHHH
 
                 // copy length - 1 :: 3 bits :: valid range [1..8]
                 //   [0..2] from command [5..7]

--- a/src/main/java/io/airlift/compress/lzo/LzoRawDecompressor.java
+++ b/src/main/java/io/airlift/compress/lzo/LzoRawDecompressor.java
@@ -48,299 +48,297 @@ public final class LzoRawDecompressor
         long input = inputAddress;
         long output = outputAddress;
 
-        boolean firstCommand = true;
-        int lastLiteralLength = 0;
-        while (true) {
-            if (input >= inputLimit) {
-                throw new MalformedInputException(input - inputAddress);
-            }
-            int command = UNSAFE.getByte(inputBase, input++) & 0xFF;
-
-            // Commands are described using a bit pattern notation:
-            // 0: bit is not set
-            // 1: bit is set
-            // L: part of literal length
-            // H: high bits of match offset position
-            // D: low bits of match offset position
-            // M: part of match length
-            // ?: see documentation in command decoder
-
-            int matchLength;
-            int matchOffset;
-            int literalLength;
-            if ((command & 0b1111_0000) == 0b0000_0000) {
-                if (lastLiteralLength == 0) {
-                    // 0b0000_LLLL (0bLLLL_LLLL)*
-                    // copy 4 or more literals only
-
-                    // copy length :: fixed
-                    //   0
-                    matchOffset = 0;
-
-                    // copy offset :: fixed
-                    //   0
-                    matchLength = 0;
-
-                    // literal length - 3 :: variable bits :: valid range [4..]
-                    //   3 + variableLength(command bits [0..3], 4)
-                    literalLength = command & 0b1111;
-                    if (literalLength == 0) {
-                        literalLength = 0b1111;
-
-                        int nextByte = 0;
-                        while (input < inputLimit && (nextByte = UNSAFE.getByte(inputBase, input++) & 0xFF) == 0) {
-                            literalLength += 0b1111_1111;
-                        }
-                        literalLength += nextByte;
-                    }
-                    literalLength += 3;
-                }
-                else if (lastLiteralLength <= 3) {
-                    // 0b0000_DDLL 0bHHHH_HHHH
-                    // copy of a 2-byte block from the dictionary within a 1kB distance
-
-                    // copy length: fixed
-                    //   2
-                    matchLength = 2;
-
-                    // copy offset :: valid range [1..1024]
-                    //   DD from command [2..3]
-                    //   HH from trailer [0..7]
-                    // offset = (HH << 2) + DD + 1
-                    if (input >= inputLimit) {
-                        throw new MalformedInputException(input - inputAddress);
-                    }
-                    matchOffset = (command & 0b1100) >>> 2;
-                    matchOffset |= (UNSAFE.getByte(inputBase, input++) & 0xFF) << 2;
-
-                    // literal length :: 2 bits :: valid range [0..3]
-                    //   [0..1] from command [0..1]
-                    literalLength = (command & 0b0000_0011);
-                }
-                else {
-                    // 0b0000_DDLL 0bHHHH_HHHH
-
-                    // copy length :: fixed
-                    //   3
-                    matchLength = 3;
-
-                    // copy offset :: 10 bits :: valid range [2049..3072]
-                    //   DD from command [2..3]
-                    //   HH from trailer [0..7]
-                    // offset = (H << 2) + D + 2049
-                    if (input >= inputLimit) {
-                        throw new MalformedInputException(input - inputAddress);
-                    }
-                    matchOffset = (command & 0b1100) >>> 2;
-                    matchOffset |= (UNSAFE.getByte(inputBase, input++) & 0xFF) << 2;
-                    matchOffset |= 0b1000_0000_0000;
-
-                    // literal length :: 2 bits :: valid range [0..3]
-                    //   [0..1] from command [0..1]
-                    literalLength = (command & 0b0000_0011);
-                }
-            }
-            else if (firstCommand) {
-                // first command has special handling when high nibble is set
-                matchLength = 0;
-                matchOffset = 0;
-                literalLength = command - 17;
-            }
-            else if ((command & 0b1111_0000) == 0b0001_0000) {
-                // 0b0001_HMMM (0bMMMM_MMMM)* 0bDDDD_DDDD_DDDD_DDLL
-
-                // copy length - 2 :: variable bits :: valid range [3..]
-                //   2 + variableLength(command bits [0..2], 3)
-                matchLength = command & 0b111;
-                if (matchLength == 0) {
-                    matchLength = 0b111;
-
-                    int nextByte = 0;
-                    while (input < inputLimit && (nextByte = UNSAFE.getByte(inputBase, input++) & 0xFF) == 0) {
-                        matchLength += 0b1111_1111;
-                    }
-                    matchLength += nextByte;
-                }
-                matchLength += 2;
-
-                // read trailer
-                if (input + SIZE_OF_SHORT > inputLimit) {
-                    throw new MalformedInputException(input - inputAddress);
-                }
-                int trailer = UNSAFE.getShort(inputBase, input) & 0xFFFF;
-                input += SIZE_OF_SHORT;
-
-                // copy offset :: 16 bits :: valid range [16383..49151]
-                //   [0..13] from trailer [2..15]
-                //   [14] if command bit [3] set
-                //   plus fixed offset 0b11_1111_1111_1111
-                matchOffset = (command & 0b1000) << 11;
-                matchOffset += trailer >> 2;
-                if (matchOffset == 0) {
-                    break;
-                }
-                matchOffset += 0b11_1111_1111_1111;
-
-                // literal length :: 2 bits :: valid range [0..3]
-                //   [0..1] from trailer [0..1]
-                literalLength = trailer & 0b11;
-            }
-            else if ((command & 0b1110_0000) == 0b0010_0000) {
-                // command in [32, 63]
-                // 0b001M_MMMM (0bMMMM_MMMM)* 0bDDDD_DDDD_DDDD_DDLL
-
-                // copy length - 2 :: variable bits :: valid range [3..]
-                //   2 + variableLength(command bits [0..4], 5)
-                matchLength = command & 0b1_1111;
-                if (matchLength == 0) {
-                    matchLength = 0b1_1111;
-
-                    int nextByte = 0;
-                    while (input < inputLimit && (nextByte = UNSAFE.getByte(inputBase, input++) & 0xFF) == 0) {
-                        matchLength += 0b1111_1111;
-                    }
-                    matchLength += nextByte;
-                }
-                matchLength += 2;
-
-                // read trailer
-                if (input + SIZE_OF_SHORT > inputLimit) {
-                    throw new MalformedInputException(input - inputAddress);
-                }
-                int trailer = UNSAFE.getShort(inputBase, input) & 0xFFFF;
-                input += SIZE_OF_SHORT;
-
-                // copy offset :: 14 bits :: valid range [0..16383]
-                //  [0..13] from trailer [2..15]
-                matchOffset = trailer >>> 2;
-
-                // literal length :: 2 bits :: valid range [0..3]
-                //   [0..1] from trailer [0..1]
-                literalLength = trailer & 0b11;
-            }
-            else if ((command & 0b1100_0000) != 0) {
-                // 0bMMMD_DDLL 0bHHHH_HHHH
-
-                // copy length - 1 :: 3 bits :: valid range [1..8]
-                //   [0..2] from command [5..7]
-                //   add 1
-                matchLength = (command & 0b1110_0000) >>> 5;
-                matchLength += 1;
-
-                // copy offset :: 11 bits :: valid range [0..4095]
-                //   [0..2] from command [2..4]
-                //   [3..10] from trailer [0..7]
+        while (input < inputLimit) {
+            boolean firstCommand = true;
+            int lastLiteralLength = 0;
+            while (true) {
                 if (input >= inputLimit) {
                     throw new MalformedInputException(input - inputAddress);
                 }
-                matchOffset = (command & 0b0001_1100) >>> 2;
-                matchOffset |= (UNSAFE.getByte(inputBase, input++) & 0xFF) << 3;
+                int command = UNSAFE.getByte(inputBase, input++) & 0xFF;
+                // Commands are described using a bit pattern notation:
+                // 0: bit is not set
+                // 1: bit is set
+                // L: part of literal length
+                // H: high bits of match offset position
+                // D: low bits of match offset position
+                // M: part of match length
+                // ?: see documentation in command decoder
 
-                // literal length :: 2 bits :: valid range [0..3]
-                //   [0..1] from command [0..1]
-                literalLength = (command & 0b0000_0011);
-            }
-            else {
-                String binary = toBinary(command);
-                throw new MalformedInputException(input - 1, "Invalid LZO command " + binary);
-            }
-            firstCommand = false;
+                int matchLength;
+                int matchOffset;
+                int literalLength;
+                if ((command & 0b1111_0000) == 0b0000_0000) {
+                    if (lastLiteralLength == 0) {
+                        // 0b0000_LLLL (0bLLLL_LLLL)*
+                        // copy 4 or more literals only
 
-            // copy match
-            if (matchLength != 0) {
-                // lzo encodes match offset minus one
-                matchOffset++;
+                        // copy length :: fixed
+                        //   0
+                        matchOffset = 0;
 
-                long matchAddress = output - matchOffset;
-                if (matchAddress < outputAddress || output + matchLength > outputLimit) {
-                    throw new MalformedInputException(input - inputAddress);
-                }
-                long matchOutputLimit = output + matchLength;
+                        // copy offset :: fixed
+                        //   0
+                        matchLength = 0;
 
-                if (output > fastOutputLimit) {
-                    // slow match copy
-                    while (output < matchOutputLimit) {
-                        UNSAFE.putByte(outputBase, output++, UNSAFE.getByte(outputBase, matchAddress++));
+                        // literal length - 3 :: variable bits :: valid range [4..]
+                        //   3 + variableLength(command bits [0..3], 4)
+                        literalLength = command & 0b1111;
+                        if (literalLength == 0) {
+                            literalLength = 0b1111;
+
+                            int nextByte = 0;
+                            while (input < inputLimit && (nextByte = UNSAFE.getByte(inputBase, input++) & 0xFF) == 0) {
+                                literalLength += 0b1111_1111;
+                            }
+                            literalLength += nextByte;
+                        }
+                        literalLength += 3;
                     }
-                }
-                else {
-                    // copy repeated sequence
-                    if (matchOffset < SIZE_OF_LONG) {
-                        // 8 bytes apart so that we can copy long-at-a-time below
-                        int increment32 = DEC_32_TABLE[matchOffset];
-                        int decrement64 = DEC_64_TABLE[matchOffset];
+                    else if (lastLiteralLength <= 3) {
+                        // 0b0000_DDLL 0bHHHH_HHHH
+                        // copy of a 2-byte block from the dictionary within a 1kB distance
 
-                        UNSAFE.putByte(outputBase, output, UNSAFE.getByte(outputBase, matchAddress));
-                        UNSAFE.putByte(outputBase, output + 1, UNSAFE.getByte(outputBase, matchAddress + 1));
-                        UNSAFE.putByte(outputBase, output + 2, UNSAFE.getByte(outputBase, matchAddress + 2));
-                        UNSAFE.putByte(outputBase, output + 3, UNSAFE.getByte(outputBase, matchAddress + 3));
-                        output += SIZE_OF_INT;
-                        matchAddress += increment32;
+                        // copy length: fixed
+                        //   2
+                        matchLength = 2;
 
-                        UNSAFE.putInt(outputBase, output, UNSAFE.getInt(outputBase, matchAddress));
-                        output += SIZE_OF_INT;
-                        matchAddress -= decrement64;
-                    }
-                    else {
-                        UNSAFE.putLong(outputBase, output, UNSAFE.getLong(outputBase, matchAddress));
-                        matchAddress += SIZE_OF_LONG;
-                        output += SIZE_OF_LONG;
-                    }
-
-                    if (matchOutputLimit >= fastOutputLimit) {
-                        if (matchOutputLimit > outputLimit) {
+                        // copy offset :: valid range [1..1024]
+                        //   DD from command [2..3]
+                        //   HH from trailer [0..7]
+                        // offset = (HH << 2) + DD + 1
+                        if (input >= inputLimit) {
                             throw new MalformedInputException(input - inputAddress);
                         }
+                        matchOffset = (command & 0b1100) >>> 2;
+                        matchOffset |= (UNSAFE.getByte(inputBase, input++) & 0xFF) << 2;
 
-                        while (output < fastOutputLimit) {
-                            UNSAFE.putLong(outputBase, output, UNSAFE.getLong(outputBase, matchAddress));
-                            matchAddress += SIZE_OF_LONG;
-                            output += SIZE_OF_LONG;
+                        // literal length :: 2 bits :: valid range [0..3]
+                        //   [0..1] from command [0..1]
+                        literalLength = (command & 0b0000_0011);
+                    }
+                    else {
+                        // 0b0000_DDLL 0bHHHH_HHHH
+
+                        // copy length :: fixed
+                        //   3
+                        matchLength = 3;
+
+                        // copy offset :: 10 bits :: valid range [2049..3072]
+                        //   DD from command [2..3]
+                        //   HH from trailer [0..7]
+                        // offset = (H << 2) + D + 2049
+                        if (input >= inputLimit) {
+                            throw new MalformedInputException(input - inputAddress);
                         }
+                        matchOffset = (command & 0b1100) >>> 2;
+                        matchOffset |= (UNSAFE.getByte(inputBase, input++) & 0xFF) << 2;
+                        matchOffset |= 0b1000_0000_0000;
 
+                        // literal length :: 2 bits :: valid range [0..3]
+                        //   [0..1] from command [0..1]
+                        literalLength = (command & 0b0000_0011);
+                    }
+                }
+                else if (firstCommand) {
+                    // first command has special handling when high nibble is set
+                    matchLength = 0;
+                    matchOffset = 0;
+                    literalLength = command - 17;
+                }
+                else if ((command & 0b1111_0000) == 0b0001_0000) {
+                    // 0b0001_HMMM (0bMMMM_MMMM)* 0bDDDD_DDDD_DDDD_DDLL
+
+                    // copy length - 2 :: variable bits :: valid range [3..]
+                    //   2 + variableLength(command bits [0..2], 3)
+                    matchLength = command & 0b111;
+                    if (matchLength == 0) {
+                        matchLength = 0b111;
+
+                        int nextByte = 0;
+                        while (input < inputLimit && (nextByte = UNSAFE.getByte(inputBase, input++) & 0xFF) == 0) {
+                            matchLength += 0b1111_1111;
+                        }
+                        matchLength += nextByte;
+                    }
+                    matchLength += 2;
+
+                    // read trailer
+                    if (input + SIZE_OF_SHORT > inputLimit) {
+                        throw new MalformedInputException(input - inputAddress);
+                    }
+                    int trailer = UNSAFE.getShort(inputBase, input) & 0xFFFF;
+                    input += SIZE_OF_SHORT;
+
+                    // copy offset :: 16 bits :: valid range [16383..49151]
+                    //   [0..13] from trailer [2..15]
+                    //   [14] if command bit [3] set
+                    //   plus fixed offset 0b11_1111_1111_1111
+                    matchOffset = (command & 0b1000) << 11;
+                    matchOffset += trailer >> 2;
+                    if (matchOffset == 0) {
+                        // match offset of zero, means that this is the last command in the sequence
+                        break;
+                    }
+                    matchOffset += 0b11_1111_1111_1111;
+
+                    // literal length :: 2 bits :: valid range [0..3]
+                    //   [0..1] from trailer [0..1]
+                    literalLength = trailer & 0b11;
+                }
+                else if ((command & 0b1110_0000) == 0b0010_0000) {
+                    // command in [32, 63]
+                    // 0b001M_MMMM (0bMMMM_MMMM)* 0bDDDD_DDDD_DDDD_DDLL
+
+                    // copy length - 2 :: variable bits :: valid range [3..]
+                    //   2 + variableLength(command bits [0..4], 5)
+                    matchLength = command & 0b1_1111;
+                    if (matchLength == 0) {
+                        matchLength = 0b1_1111;
+
+                        int nextByte = 0;
+                        while (input < inputLimit && (nextByte = UNSAFE.getByte(inputBase, input++) & 0xFF) == 0) {
+                            matchLength += 0b1111_1111;
+                        }
+                        matchLength += nextByte;
+                    }
+                    matchLength += 2;
+
+                    // read trailer
+                    if (input + SIZE_OF_SHORT > inputLimit) {
+                        throw new MalformedInputException(input - inputAddress);
+                    }
+                    int trailer = UNSAFE.getShort(inputBase, input) & 0xFFFF;
+                    input += SIZE_OF_SHORT;
+
+                    // copy offset :: 14 bits :: valid range [0..16383]
+                    //  [0..13] from trailer [2..15]
+                    matchOffset = trailer >>> 2;
+
+                    // literal length :: 2 bits :: valid range [0..3]
+                    //   [0..1] from trailer [0..1]
+                    literalLength = trailer & 0b11;
+                }
+                else if ((command & 0b1100_0000) != 0) {
+                    // 0bMMMD_DDLL 0bHHHH_HHHH
+
+                    // copy length - 1 :: 3 bits :: valid range [1..8]
+                    //   [0..2] from command [5..7]
+                    //   add 1
+                    matchLength = (command & 0b1110_0000) >>> 5;
+                    matchLength += 1;
+
+                    // copy offset :: 11 bits :: valid range [0..4095]
+                    //   [0..2] from command [2..4]
+                    //   [3..10] from trailer [0..7]
+                    if (input >= inputLimit) {
+                        throw new MalformedInputException(input - inputAddress);
+                    }
+                    matchOffset = (command & 0b0001_1100) >>> 2;
+                    matchOffset |= (UNSAFE.getByte(inputBase, input++) & 0xFF) << 3;
+
+                    // literal length :: 2 bits :: valid range [0..3]
+                    //   [0..1] from command [0..1]
+                    literalLength = (command & 0b0000_0011);
+                }
+                else {
+                    String binary = toBinary(command);
+                    throw new MalformedInputException(input - 1, "Invalid LZO command " + binary);
+                }
+                firstCommand = false;
+
+                // copy match
+                if (matchLength != 0) {
+                    // lzo encodes match offset minus one
+                    matchOffset++;
+
+                    long matchAddress = output - matchOffset;
+                    if (matchAddress < outputAddress || output + matchLength > outputLimit) {
+                        throw new MalformedInputException(input - inputAddress);
+                    }
+                    long matchOutputLimit = output + matchLength;
+
+                    if (output > fastOutputLimit) {
+                        // slow match copy
                         while (output < matchOutputLimit) {
                             UNSAFE.putByte(outputBase, output++, UNSAFE.getByte(outputBase, matchAddress++));
                         }
                     }
                     else {
-                        while (output < matchOutputLimit) {
+                        // copy repeated sequence
+                        if (matchOffset < SIZE_OF_LONG) {
+                            // 8 bytes apart so that we can copy long-at-a-time below
+                            int increment32 = DEC_32_TABLE[matchOffset];
+                            int decrement64 = DEC_64_TABLE[matchOffset];
+
+                            UNSAFE.putByte(outputBase, output, UNSAFE.getByte(outputBase, matchAddress));
+                            UNSAFE.putByte(outputBase, output + 1, UNSAFE.getByte(outputBase, matchAddress + 1));
+                            UNSAFE.putByte(outputBase, output + 2, UNSAFE.getByte(outputBase, matchAddress + 2));
+                            UNSAFE.putByte(outputBase, output + 3, UNSAFE.getByte(outputBase, matchAddress + 3));
+                            output += SIZE_OF_INT;
+                            matchAddress += increment32;
+
+                            UNSAFE.putInt(outputBase, output, UNSAFE.getInt(outputBase, matchAddress));
+                            output += SIZE_OF_INT;
+                            matchAddress -= decrement64;
+                        }
+                        else {
                             UNSAFE.putLong(outputBase, output, UNSAFE.getLong(outputBase, matchAddress));
                             matchAddress += SIZE_OF_LONG;
                             output += SIZE_OF_LONG;
                         }
+
+                        if (matchOutputLimit >= fastOutputLimit) {
+                            if (matchOutputLimit > outputLimit) {
+                                throw new MalformedInputException(input - inputAddress);
+                            }
+
+                            while (output < fastOutputLimit) {
+                                UNSAFE.putLong(outputBase, output, UNSAFE.getLong(outputBase, matchAddress));
+                                matchAddress += SIZE_OF_LONG;
+                                output += SIZE_OF_LONG;
+                            }
+
+                            while (output < matchOutputLimit) {
+                                UNSAFE.putByte(outputBase, output++, UNSAFE.getByte(outputBase, matchAddress++));
+                            }
+                        }
+                        else {
+                            while (output < matchOutputLimit) {
+                                UNSAFE.putLong(outputBase, output, UNSAFE.getLong(outputBase, matchAddress));
+                                matchAddress += SIZE_OF_LONG;
+                                output += SIZE_OF_LONG;
+                            }
+                        }
                     }
-                }
-                output = matchOutputLimit; // correction in case we over-copied
-            }
-
-            // copy literal
-            long literalOutputLimit = output + literalLength;
-            if (literalOutputLimit > fastOutputLimit || input + literalLength > inputLimit - SIZE_OF_LONG) {
-                if (literalOutputLimit > outputLimit) {
-                    throw new MalformedInputException(input - inputAddress);
+                    output = matchOutputLimit; // correction in case we over-copied
                 }
 
-                // slow, precise copy
-                UNSAFE.copyMemory(inputBase, input, outputBase, output, literalLength);
-                input += literalLength;
-                output += literalLength;
-            }
-            else {
-                // fast copy. We may over-copy but there's enough room in input and output to not overrun them
-                do {
-                    UNSAFE.putLong(outputBase, output, UNSAFE.getLong(inputBase, input));
-                    input += SIZE_OF_LONG;
-                    output += SIZE_OF_LONG;
-                }
-                while (output < literalOutputLimit);
-                input -= (output - literalOutputLimit); // adjust index if we over-copied
-                output = literalOutputLimit;
-            }
-            lastLiteralLength = literalLength;
-        }
+                // copy literal
+                long literalOutputLimit = output + literalLength;
+                if (literalOutputLimit > fastOutputLimit || input + literalLength > inputLimit - SIZE_OF_LONG) {
+                    if (literalOutputLimit > outputLimit) {
+                        throw new MalformedInputException(input - inputAddress);
+                    }
 
-        if (input != inputLimit) {
-            throw new MalformedInputException(input - inputAddress);
+                    // slow, precise copy
+                    UNSAFE.copyMemory(inputBase, input, outputBase, output, literalLength);
+                    input += literalLength;
+                    output += literalLength;
+                }
+                else {
+                    // fast copy. We may over-copy but there's enough room in input and output to not overrun them
+                    do {
+                        UNSAFE.putLong(outputBase, output, UNSAFE.getLong(inputBase, input));
+                        input += SIZE_OF_LONG;
+                        output += SIZE_OF_LONG;
+                    }
+                    while (output < literalOutputLimit);
+                    input -= (output - literalOutputLimit); // adjust index if we over-copied
+                    output = literalOutputLimit;
+                }
+                lastLiteralLength = literalLength;
+            }
         }
         return (int) (output - outputAddress);
     }

--- a/src/test/java/io/airlift/compress/lzo/TestLzo.java
+++ b/src/test/java/io/airlift/compress/lzo/TestLzo.java
@@ -18,6 +18,7 @@ import io.airlift.compress.Compressor;
 import io.airlift.compress.Decompressor;
 import io.airlift.compress.HadoopNative;
 import io.airlift.compress.thirdparty.HadoopLzoCompressor;
+import io.airlift.compress.thirdparty.HadoopLzoDecompressor;
 
 public class TestLzo
         extends AbstractTestCompression
@@ -47,8 +48,6 @@ public class TestLzo
     @Override
     protected Decompressor getVerifyDecompressor()
     {
-        // The hadoop decompressor can not deal with multiple compressed blocks
-        // todo write a verify decompressor that handles the consecutive blocks, but uses the native code
-        return new LzoDecompressor();
+        return new HadoopLzoDecompressor();
     }
 }

--- a/src/test/java/io/airlift/compress/thirdparty/HadoopLzoCompressor.java
+++ b/src/test/java/io/airlift/compress/thirdparty/HadoopLzoCompressor.java
@@ -20,8 +20,6 @@ import org.anarres.lzo.hadoop.codec.LzoCompressor;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 public class HadoopLzoCompressor
         implements Compressor
 {
@@ -29,13 +27,12 @@ public class HadoopLzoCompressor
         HadoopNative.requireHadoopNative();
     }
 
-    private static final int maxOutputBufferSize = 128 * 1024 * 1024;
     private final org.apache.hadoop.io.compress.Compressor compressor;
 
     public HadoopLzoCompressor()
     {
-        // use a large enough buffer to avoid framing
-        compressor = new LzoCompressor(LzoCompressor.CompressionStrategy.LZO1X_1, maxOutputBufferSize);
+        // use a small buffer so we get multiple compressed chunks
+        compressor = new LzoCompressor(LzoCompressor.CompressionStrategy.LZO1X_1, 256 * 1024);
     }
 
     @Override
@@ -47,7 +44,6 @@ public class HadoopLzoCompressor
     @Override
     public int compress(byte[] input, int inputOffset, int inputLength, byte[] output, int outputOffset, int maxOutputLength)
     {
-        checkArgument(inputLength < maxOutputBufferSize, "input size " + inputLength + " exceed maximum size : " + maxOutputLength);
         compressor.reset();
         compressor.setInput(input, inputOffset, inputLength);
         compressor.finish();

--- a/src/test/java/io/airlift/compress/thirdparty/HadoopLzoDecompressor.java
+++ b/src/test/java/io/airlift/compress/thirdparty/HadoopLzoDecompressor.java
@@ -13,37 +13,41 @@
  */
 package io.airlift.compress.thirdparty;
 
-import com.hadoop.compression.lzo.LzoCodec;
 import io.airlift.compress.Decompressor;
 import io.airlift.compress.HadoopNative;
 import io.airlift.compress.MalformedInputException;
-import org.apache.hadoop.conf.Configuration;
+import org.anarres.lzo.hadoop.codec.LzoDecompressor;
+import org.anarres.lzo.hadoop.codec.LzoDecompressor.CompressionStrategy;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 public class HadoopLzoDecompressor
-    implements Decompressor
+        implements Decompressor
 {
     static {
         HadoopNative.requireHadoopNative();
     }
-
-    private static final Configuration HADOOP_CONF = new Configuration();
-
+    private static final int maxOutputBufferSize = 128 * 1024 * 1024;
     private final org.apache.hadoop.io.compress.Decompressor decompressor;
 
     public HadoopLzoDecompressor()
     {
-        LzoCodec codec = new LzoCodec();
-        codec.setConf(HADOOP_CONF);
-        decompressor = codec.createDecompressor();
+        decompressor = new LzoDecompressor(CompressionStrategy.LZO1X, maxOutputBufferSize);
     }
 
     @Override
     public int decompress(byte[] input, int inputOffset, int inputLength, byte[] output, int outputOffset, int maxOutputLength)
             throws MalformedInputException
     {
+        checkArgument(inputLength < maxOutputBufferSize, "input size " + inputLength + " exceed maximum size : " + maxOutputLength);
+        // nothing decompress to nothing
+        if (inputLength == 0) {
+            return 0;
+        }
+
         decompressor.reset();
         decompressor.setInput(input, inputOffset, inputLength);
 


### PR DESCRIPTION
There are a few issues in the current implementation of LZO compressor and decompressor.
- LzoRawDecompressor doesn't decode the command in LZO1X format correctly
- Unit tests are broken
  - verify decompressor in `TestLzo` is not set to the Hadoop Lzo implementation
  - the HadoopLzoCompressor doesn't round-trip with HadoopLzoDecompressor

This PR fixes the above issues.

@dain 