### PR TITLE
Optimize match length count function

### DIFF
--- a/src/test/java/io/airlift/compress/lz4/BenchmarkCount.java
+++ b/src/test/java/io/airlift/compress/lz4/BenchmarkCount.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.compress.lz4;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
+import org.openjdk.jmh.runner.options.CommandLineOptionException;
+import org.openjdk.jmh.runner.options.CommandLineOptions;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
+
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@BenchmarkMode(Mode.AverageTime)
+@Measurement(iterations = 10)
+@Warmup(iterations = 5)
+@Fork(3)
+public class BenchmarkCount
+{
+    @Param({"1", "3", "7", "15", "127", "511"})
+    private int matchLength;
+
+    @Param({"0", "1", "3", "7", "50"})
+    private int padding;
+
+    private byte[] data;
+
+    @Setup
+    public void setup()
+    {
+        int size = (matchLength + 1) * 2 + padding;
+        data = new byte[size];
+
+        byte[] pattern = new byte[matchLength];
+        ThreadLocalRandom.current().nextBytes(pattern);
+
+        System.arraycopy(pattern, 0, data, 0, matchLength);
+        data[matchLength] = 1;
+
+        System.arraycopy(pattern, 0, data, matchLength + 1, matchLength);
+        data[matchLength + 1 + matchLength] = 2;
+    }
+
+    @Benchmark
+    public long count()
+    {
+        return Lz4RawCompressor.count(data, ARRAY_BYTE_BASE_OFFSET + matchLength + 1, ARRAY_BYTE_BASE_OFFSET + data.length, ARRAY_BYTE_BASE_OFFSET);
+    }
+
+    public static void main(String[] args)
+            throws RunnerException, CommandLineOptionException
+    {
+        CommandLineOptions parsedOptions = new CommandLineOptions(args);
+        ChainedOptionsBuilder options = new OptionsBuilder()
+                .parent(parsedOptions);
+
+        if (parsedOptions.getIncludes().isEmpty()) {
+            options = options.include(".*\\." + BenchmarkCount.class.getSimpleName() + ".*");
+        }
+
+        new Runner(options.build()).run();
+    }
+}


### PR DESCRIPTION
Using a counted loop improves performance, especially for long matches

```
Benchmark (matchLength)  (padding)  Mode  Cnt   Score   Error  Units
before                1          0  avgt   30   4.452 ± 0.074  ns/op
after                 1          0  avgt   30   4.450 ± 0.292  ns/op

before                1          1  avgt   30   4.438 ± 0.069  ns/op
after                 1          1  avgt   30   4.178 ± 0.097  ns/op

before                1          3  avgt   30   4.600 ± 0.111  ns/op
after                 1          3  avgt   30   4.231 ± 0.162  ns/op

before                1          7  avgt   30   4.276 ± 0.089  ns/op
after                 1          7  avgt   30   3.863 ± 0.065  ns/op

before                1         50  avgt   30   4.302 ± 0.093  ns/op
after                 1         50  avgt   30   3.867 ± 0.059  ns/op

before                3          0  avgt   30   4.745 ± 0.025  ns/op
after                 3          0  avgt   30   4.198 ± 0.103  ns/op

before                3          1  avgt   30   4.784 ± 0.058  ns/op
after                 3          1  avgt   30   4.176 ± 0.070  ns/op

before                3          3  avgt   30   4.807 ± 0.133  ns/op
after                 3          3  avgt   30   4.165 ± 0.091  ns/op

before                3          7  avgt   30   4.311 ± 0.132  ns/op
after                 3          7  avgt   30   3.821 ± 0.029  ns/op

before                3         50  avgt   30   4.289 ± 0.099  ns/op
after                 3         50  avgt   30   3.831 ± 0.085  ns/op

before                7          0  avgt   30   4.232 ± 0.038  ns/op
after                 7          0  avgt   30   3.908 ± 0.121  ns/op

before                7          1  avgt   30   4.210 ± 0.043  ns/op
after                 7          1  avgt   30   3.924 ± 0.085  ns/op

before                7          3  avgt   30   4.179 ± 0.123  ns/op
after                 7          3  avgt   30   3.845 ± 0.085  ns/op

before                7          7  avgt   30   4.226 ± 0.114  ns/op
after                 7          7  avgt   30   3.803 ± 0.031  ns/op

before                7         50  avgt   30   4.271 ± 0.129  ns/op
after                 7         50  avgt   30   3.842 ± 0.085  ns/op

before               15          0  avgt   30   4.848 ± 0.095  ns/op
after                15          0  avgt   30   4.397 ± 0.111  ns/op

before               15          1  avgt   30   4.813 ± 0.045  ns/op
after                15          1  avgt   30   4.384 ± 0.087  ns/op

before               15          3  avgt   30   4.835 ± 0.096  ns/op
after                15          3  avgt   30   4.422 ± 0.116  ns/op

before               15          7  avgt   30   4.863 ± 0.075  ns/op
after                15          7  avgt   30   4.413 ± 0.046  ns/op

before               15         50  avgt   30   4.917 ± 0.143  ns/op
after                15         50  avgt   30   4.364 ± 0.044  ns/op

before              127          0  avgt   30  14.394 ± 0.320  ns/op
after               127          0  avgt   30  11.832 ± 0.396  ns/op

before              127          1  avgt   30  14.352 ± 0.273  ns/op
after               127          1  avgt   30  11.543 ± 0.275  ns/op

before              127          3  avgt   30  14.290 ± 0.142  ns/op
after               127          3  avgt   30  11.709 ± 0.293  ns/op

before              127          7  avgt   30  15.361 ± 2.277  ns/op
after               127          7  avgt   30  11.657 ± 0.296  ns/op

before              127         50  avgt   30  14.121 ± 0.301  ns/op
after               127         50  avgt   30  10.911 ± 0.450  ns/op

before              511          0  avgt   30  47.233 ± 0.905  ns/op
after               511          0  avgt   30  31.330 ± 2.087  ns/op

before              511          1  avgt   30  47.137 ± 0.529  ns/op
after               511          1  avgt   30  30.074 ± 1.008  ns/op

before              511          3  avgt   30  47.017 ± 0.474  ns/op
after               511          3  avgt   30  30.523 ± 1.856  ns/op

before              511          7  avgt   30  46.510 ± 0.441  ns/op
after               511          7  avgt   30  31.102 ± 4.902  ns/op

before              511         50  avgt   30  46.789 ± 1.311  ns/op
after               511         50  avgt   30  27.405 ± 0.225  ns/op
```