### PR TITLE
Make ZstdFrameCompressor public

### DIFF
--- a/src/main/java/io/airlift/compress/zstd/ZstdFrameCompressor.java
+++ b/src/main/java/io/airlift/compress/zstd/ZstdFrameCompressor.java
@@ -38,7 +38,7 @@ import static io.airlift.compress.zstd.Util.checkArgument;
 import static io.airlift.compress.zstd.Util.put24BitLittleEndian;
 import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
 
-class ZstdFrameCompressor
+public class ZstdFrameCompressor
 {
     static final int MAX_FRAME_HEADER_SIZE = 14;
 

--- a/src/main/java/io/airlift/compress/zstd/ZstdFrameDecompressor.java
+++ b/src/main/java/io/airlift/compress/zstd/ZstdFrameDecompressor.java
@@ -58,7 +58,7 @@ import static io.airlift.compress.zstd.Util.mask;
 import static io.airlift.compress.zstd.Util.verify;
 import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
 
-class ZstdFrameDecompressor
+public class ZstdFrameDecompressor
 {
     private static final int[] DEC_32_TABLE = {4, 1, 2, 1, 4, 4, 4, 4};
     private static final int[] DEC_64_TABLE = {0, 0, 0, -1, 0, 1, 2, 3};


### PR DESCRIPTION
In order to do direct compression on a memory region, it would be good to be able to call `ZstdFrameCompressor.compress()` without intermediaries.