### PR TITLE
Update compression libraries to latest versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>io.airlift</groupId>
         <artifactId>airbase</artifactId>
-        <version>83</version>
+        <version>95</version>
     </parent>
 
     <inceptionYear>2011</inceptionYear>
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>org.xerial.snappy</groupId>
             <artifactId>snappy-java</artifactId>
-            <version>1.1.1.7</version>
+            <version>1.1.7.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -103,23 +103,23 @@
         </dependency>
 
         <dependency>
-            <groupId>net.jpountz.lz4</groupId>
-            <artifactId>lz4</artifactId>
-            <version>1.3.0</version>
+            <groupId>org.lz4</groupId>
+            <artifactId>lz4-java</artifactId>
+            <version>1.7.1</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>com.github.luben</groupId>
             <artifactId>zstd-jni</artifactId>
-            <version>1.3.5-4</version>
+            <version>1.4.4-4</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.anarres.lzo</groupId>
             <artifactId>lzo-hadoop</artifactId>
-            <version>1.0.5</version>
+            <version>1.0.6</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -140,7 +140,7 @@
         <dependency>
             <groupId>com.facebook.presto.hadoop</groupId>
             <artifactId>hadoop-apache2</artifactId>
-            <version>0.3</version>
+            <version>3.2.0-1</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/test/java/io/airlift/compress/benchmark/Algorithm.java
+++ b/src/test/java/io/airlift/compress/benchmark/Algorithm.java
@@ -40,6 +40,7 @@ import io.airlift.compress.thirdparty.ZstdJniCompressor;
 import io.airlift.compress.thirdparty.ZstdJniDecompressor;
 import io.airlift.compress.zstd.ZstdCompressor;
 import io.airlift.compress.zstd.ZstdDecompressor;
+import net.jpountz.lz4.LZ4Factory;
 import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.compress.CompressionCodec;
@@ -55,7 +56,9 @@ public enum Algorithm
     airlift_snappy_stream(new SnappyCodec(), new SnappyCompressor()),
     airlift_lzo_stream(new LzoCodec(), new LzoCompressor()),
 
-    jpountz_lz4_jni(new JPountzLz4JniDecompressor(), new JPountzLz4JniCompressor()),
+    jpountz_lz4_jni(new JPountzLz4JniDecompressor(LZ4Factory.nativeInstance()), new JPountzLz4JniCompressor(LZ4Factory.nativeInstance())),
+    jpountz_lz4_safe(new JPountzLz4JniDecompressor(LZ4Factory.safeInstance()), new JPountzLz4JniCompressor(LZ4Factory.safeInstance())),
+    jpountz_lz4_unsafe(new JPountzLz4JniDecompressor(LZ4Factory.unsafeInstance()), new JPountzLz4JniCompressor(LZ4Factory.unsafeInstance())),
     xerial_snappy(new XerialSnappyDecompressor(), new XerialSnappyCompressor()),
     iq80_snappy(new Iq80SnappyDecompressor(), new Iq80SnappyCompressor()),
     hadoop_lzo(new HadoopLzoDecompressor(), new HadoopLzoCompressor()),

--- a/src/test/java/io/airlift/compress/benchmark/CompressionBenchmark.java
+++ b/src/test/java/io/airlift/compress/benchmark/CompressionBenchmark.java
@@ -64,6 +64,8 @@ public class CompressionBenchmark
             "iq80_snappy",
             "xerial_snappy",
             "jpountz_lz4_jni",
+            "jpountz_lz4_safe",
+            "jpountz_lz4_unsafe",
             "hadoop_lzo",
             "zstd_jni",
 

--- a/src/test/java/io/airlift/compress/lz4/TestLz4.java
+++ b/src/test/java/io/airlift/compress/lz4/TestLz4.java
@@ -18,6 +18,7 @@ import io.airlift.compress.Compressor;
 import io.airlift.compress.Decompressor;
 import io.airlift.compress.thirdparty.JPountzLz4JniCompressor;
 import io.airlift.compress.thirdparty.JPountzLz4JniDecompressor;
+import net.jpountz.lz4.LZ4Factory;
 
 public class TestLz4
         extends AbstractTestCompression
@@ -37,12 +38,12 @@ public class TestLz4
     @Override
     protected Compressor getVerifyCompressor()
     {
-        return new JPountzLz4JniCompressor();
+        return new JPountzLz4JniCompressor(LZ4Factory.fastestInstance());
     }
 
     @Override
     protected Decompressor getVerifyDecompressor()
     {
-        return new JPountzLz4JniDecompressor();
+        return new JPountzLz4JniDecompressor(LZ4Factory.fastestInstance());
     }
 }

--- a/src/test/java/io/airlift/compress/thirdparty/JPountzLz4JniCompressor.java
+++ b/src/test/java/io/airlift/compress/thirdparty/JPountzLz4JniCompressor.java
@@ -22,7 +22,11 @@ import java.nio.ByteBuffer;
 public class JPountzLz4JniCompressor
         implements Compressor
 {
-    private final LZ4Compressor compressor = LZ4Factory.fastestInstance().fastCompressor();
+    private final LZ4Compressor compressor;
+
+    public JPountzLz4JniCompressor(LZ4Factory factory) {
+        compressor = factory.fastCompressor();
+    }
 
     @Override
     public int maxCompressedLength(int uncompressedSize)
@@ -39,6 +43,6 @@ public class JPountzLz4JniCompressor
     @Override
     public void compress(ByteBuffer input, ByteBuffer output)
     {
-        throw new UnsupportedOperationException("not yet implemented");
+        compressor.compress(input, output);
     }
 }

--- a/src/test/java/io/airlift/compress/thirdparty/JPountzLz4JniDecompressor.java
+++ b/src/test/java/io/airlift/compress/thirdparty/JPountzLz4JniDecompressor.java
@@ -23,7 +23,11 @@ import java.nio.ByteBuffer;
 public class JPountzLz4JniDecompressor
         implements Decompressor
 {
-    private final LZ4SafeDecompressor decompressor = LZ4Factory.fastestInstance().safeDecompressor();
+    private final LZ4SafeDecompressor decompressor;
+
+    public JPountzLz4JniDecompressor(LZ4Factory factory) {
+        decompressor = factory.safeDecompressor();
+    }
 
     @Override
     public int decompress(byte[] input, int inputOffset, int inputLength, byte[] output, int outputOffset, int maxOutputLength)
@@ -36,6 +40,6 @@ public class JPountzLz4JniDecompressor
     public void decompress(ByteBuffer input, ByteBuffer output)
             throws MalformedInputException
     {
-        throw new UnsupportedOperationException("not yet implemented");
+        decompressor.decompress(input, output);
     }
 }

--- a/src/test/java/io/airlift/compress/thirdparty/XerialSnappyCompressor.java
+++ b/src/test/java/io/airlift/compress/thirdparty/XerialSnappyCompressor.java
@@ -15,6 +15,7 @@ package io.airlift.compress.thirdparty;
 
 import io.airlift.compress.Compressor;
 import io.airlift.compress.snappy.SnappyCompressor;
+import org.xerial.snappy.Snappy;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -42,6 +43,11 @@ public class XerialSnappyCompressor
     @Override
     public void compress(ByteBuffer input, ByteBuffer output)
     {
-        throw new UnsupportedOperationException("not yet implemented");
+        try {
+            org.xerial.snappy.Snappy.compress(input, output);
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/test/java/io/airlift/compress/thirdparty/XerialSnappyDecompressor.java
+++ b/src/test/java/io/airlift/compress/thirdparty/XerialSnappyDecompressor.java
@@ -15,6 +15,7 @@ package io.airlift.compress.thirdparty;
 
 import io.airlift.compress.Decompressor;
 import io.airlift.compress.MalformedInputException;
+import org.xerial.snappy.Snappy;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -38,6 +39,11 @@ public class XerialSnappyDecompressor
     public void decompress(ByteBuffer input, ByteBuffer output)
             throws MalformedInputException
     {
-        throw new UnsupportedOperationException("not yet implemented");
+        try {
+            org.xerial.snappy.Snappy.uncompress(input, output);
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/test/java/io/airlift/compress/thirdparty/ZstdJniCompressor.java
+++ b/src/test/java/io/airlift/compress/thirdparty/ZstdJniCompressor.java
@@ -17,7 +17,6 @@ import com.github.luben.zstd.Zstd;
 import io.airlift.compress.Compressor;
 
 import java.nio.ByteBuffer;
-import java.util.Arrays;
 
 public class ZstdJniCompressor
         implements Compressor
@@ -38,23 +37,12 @@ public class ZstdJniCompressor
     @Override
     public int compress(byte[] input, int inputOffset, int inputLength, byte[] output, int outputOffset, int maxOutputLength)
     {
-        byte[] uncompressed = Arrays.copyOfRange(input, inputOffset, inputLength);
-        byte[] compressed = Zstd.compress(uncompressed, level);
-
-        System.arraycopy(compressed, 0, output, outputOffset, compressed.length);
-
-        return compressed.length;
+        return (int) Zstd.compressByteArray(output, outputOffset, maxOutputLength, input, inputOffset, inputLength, level);
     }
 
     @Override
     public void compress(ByteBuffer input, ByteBuffer output)
     {
-        byte[] uncompressed = new byte[input.remaining()];
-        input.get(uncompressed);
-
-        byte[] compressed = new byte[output.remaining()];
-
-        int compressedSize = compress(uncompressed, 0, uncompressed.length, compressed, 0, compressed.length);
-        output.put(compressed, 0, compressedSize);
+        Zstd.compress(input, output, level);
     }
 }

--- a/src/test/java/io/airlift/compress/thirdparty/ZstdJniDecompressor.java
+++ b/src/test/java/io/airlift/compress/thirdparty/ZstdJniDecompressor.java
@@ -18,7 +18,6 @@ import io.airlift.compress.Decompressor;
 import io.airlift.compress.MalformedInputException;
 
 import java.nio.ByteBuffer;
-import java.util.Arrays;
 
 public class ZstdJniDecompressor
         implements Decompressor
@@ -27,18 +26,13 @@ public class ZstdJniDecompressor
     public int decompress(byte[] input, int inputOffset, int inputLength, byte[] output, int outputOffset, int maxOutputLength)
             throws MalformedInputException
     {
-        byte[] compressed = Arrays.copyOfRange(input, inputOffset, inputLength);
-        byte[] uncompressed = Zstd.decompress(compressed, maxOutputLength);
-
-        System.arraycopy(uncompressed, 0, output, outputOffset, uncompressed.length);
-
-        return uncompressed.length;
+        return (int) Zstd.decompressByteArray(output, outputOffset, maxOutputLength, input, inputOffset, inputLength);
     }
 
     @Override
     public void decompress(ByteBuffer input, ByteBuffer output)
             throws MalformedInputException
     {
-        throw new UnsupportedOperationException("not yet implemented");
+        Zstd.decompress(output, input);
     }
 }


### PR DESCRIPTION
The latest versions have received many improvements and perform much better in benchmarks. They also implement more of the APIs being evaluated.