### PR TITLE
Make SnappyCompressor stateless

### DIFF
--- a/src/main/java/io/airlift/compress/snappy/SnappyCompressor.java
+++ b/src/main/java/io/airlift/compress/snappy/SnappyCompressor.java
@@ -23,8 +23,6 @@ import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
 public class SnappyCompressor
         implements Compressor
 {
-    private final short[] table = new short[SnappyRawCompressor.MAX_HASH_TABLE_SIZE];
-
     @Override
     public int maxCompressedLength(int uncompressedSize)
     {
@@ -38,6 +36,7 @@ public class SnappyCompressor
         long inputLimit = inputAddress + inputLength;
         long outputAddress = ARRAY_BYTE_BASE_OFFSET + outputOffset;
         long outputLimit = outputAddress + maxOutputLength;
+        final short[] table = new short[SnappyRawCompressor.MAX_HASH_TABLE_SIZE];
 
         return SnappyRawCompressor.compress(input, inputAddress, inputLimit, output, outputAddress, outputLimit, table);
     }
@@ -48,6 +47,7 @@ public class SnappyCompressor
         Object inputBase;
         long inputAddress;
         long inputLimit;
+        final short[] table = new short[SnappyRawCompressor.MAX_HASH_TABLE_SIZE];
         if (input.isDirect()) {
             inputBase = null;
             long address = getAddress(input);


### PR DESCRIPTION
moved the table field to be a local variable instead of an object instance, this should make this service stateless and avoid synchronization or creating new instances in multi-threaded applications.