### PR TITLE
Update zstd-jni to latest versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <dependency>
             <groupId>com.github.luben</groupId>
             <artifactId>zstd-jni</artifactId>
-            <version>1.4.4-7</version>
+            <version>1.4.9-1</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
In my local, unscientific benchmark, the new version of zstd-jni generally performs better than the older version. The project has indicated several improvements have been made.