### PR TITLE
Remove support for direct byte buffers

### DIFF
--- a/src/main/java/io/airlift/compress/lz4/Lz4Compressor.java
+++ b/src/main/java/io/airlift/compress/lz4/Lz4Compressor.java
@@ -18,7 +18,6 @@ import io.airlift.compress.Compressor;
 import java.nio.ByteBuffer;
 
 import static io.airlift.compress.lz4.Lz4RawCompressor.MAX_TABLE_SIZE;
-import static io.airlift.compress.lz4.UnsafeUtil.getAddress;
 import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
 
 /**
@@ -50,13 +49,7 @@ public class Lz4Compressor
         Object inputBase;
         long inputAddress;
         long inputLimit;
-        if (input.isDirect()) {
-            inputBase = null;
-            long address = getAddress(input);
-            inputAddress = address + input.position();
-            inputLimit = address + input.limit();
-        }
-        else if (input.hasArray()) {
+        if (input.hasArray()) {
             inputBase = input.array();
             inputAddress = ARRAY_BYTE_BASE_OFFSET + input.arrayOffset() + input.position();
             inputLimit = ARRAY_BYTE_BASE_OFFSET + input.arrayOffset() + input.limit();
@@ -68,13 +61,7 @@ public class Lz4Compressor
         Object outputBase;
         long outputAddress;
         long outputLimit;
-        if (output.isDirect()) {
-            outputBase = null;
-            long address = getAddress(output);
-            outputAddress = address + output.position();
-            outputLimit = address + output.limit();
-        }
-        else if (output.hasArray()) {
+        if (output.hasArray()) {
             outputBase = output.array();
             outputAddress = ARRAY_BYTE_BASE_OFFSET + output.arrayOffset() + output.position();
             outputLimit = ARRAY_BYTE_BASE_OFFSET + output.arrayOffset() + output.limit();

--- a/src/main/java/io/airlift/compress/lz4/Lz4Decompressor.java
+++ b/src/main/java/io/airlift/compress/lz4/Lz4Decompressor.java
@@ -18,7 +18,6 @@ import io.airlift.compress.MalformedInputException;
 
 import java.nio.ByteBuffer;
 
-import static io.airlift.compress.lz4.UnsafeUtil.getAddress;
 import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
 
 public class Lz4Decompressor
@@ -43,13 +42,7 @@ public class Lz4Decompressor
         Object inputBase;
         long inputAddress;
         long inputLimit;
-        if (input.isDirect()) {
-            inputBase = null;
-            long address = getAddress(input);
-            inputAddress = address + input.position();
-            inputLimit = address + input.limit();
-        }
-        else if (input.hasArray()) {
+        if (input.hasArray()) {
             inputBase = input.array();
             inputAddress = ARRAY_BYTE_BASE_OFFSET + input.arrayOffset() + input.position();
             inputLimit = ARRAY_BYTE_BASE_OFFSET + input.arrayOffset() + input.limit();
@@ -61,13 +54,7 @@ public class Lz4Decompressor
         Object outputBase;
         long outputAddress;
         long outputLimit;
-        if (output.isDirect()) {
-            outputBase = null;
-            long address = getAddress(output);
-            outputAddress = address + output.position();
-            outputLimit = address + output.limit();
-        }
-        else if (output.hasArray()) {
+        if (output.hasArray()) {
             outputBase = output.array();
             outputAddress = ARRAY_BYTE_BASE_OFFSET + output.arrayOffset() + output.position();
             outputLimit = ARRAY_BYTE_BASE_OFFSET + output.arrayOffset() + output.limit();

--- a/src/main/java/io/airlift/compress/lz4/UnsafeUtil.java
+++ b/src/main/java/io/airlift/compress/lz4/UnsafeUtil.java
@@ -17,7 +17,6 @@ import io.airlift.compress.IncompatibleJvmException;
 import sun.misc.Unsafe;
 
 import java.lang.reflect.Field;
-import java.nio.Buffer;
 import java.nio.ByteOrder;
 
 import static java.lang.String.format;
@@ -25,7 +24,6 @@ import static java.lang.String.format;
 final class UnsafeUtil
 {
     public static final Unsafe UNSAFE;
-    private static final Field ADDRESS_ACCESSOR;
 
     private UnsafeUtil() {}
 
@@ -42,25 +40,6 @@ final class UnsafeUtil
         }
         catch (Exception e) {
             throw new IncompatibleJvmException("LZ4 requires access to sun.misc.Unsafe");
-        }
-
-        try {
-            Field field = Buffer.class.getDeclaredField("address");
-            field.setAccessible(true);
-            ADDRESS_ACCESSOR = field;
-        }
-        catch (Exception e) {
-            throw new IncompatibleJvmException("LZ4 requires access to java.nio.Buffer raw address field");
-        }
-    }
-
-    public static long getAddress(Buffer buffer)
-    {
-        try {
-            return (long) ADDRESS_ACCESSOR.get(buffer);
-        }
-        catch (IllegalAccessException e) {
-            throw new RuntimeException(e);
         }
     }
 }

--- a/src/main/java/io/airlift/compress/lzo/LzoCompressor.java
+++ b/src/main/java/io/airlift/compress/lzo/LzoCompressor.java
@@ -18,7 +18,6 @@ import io.airlift.compress.Compressor;
 import java.nio.ByteBuffer;
 
 import static io.airlift.compress.lzo.LzoRawCompressor.MAX_TABLE_SIZE;
-import static io.airlift.compress.lzo.UnsafeUtil.getAddress;
 import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
 
 /**
@@ -50,13 +49,7 @@ public class LzoCompressor
         Object inputBase;
         long inputAddress;
         long inputLimit;
-        if (input.isDirect()) {
-            inputBase = null;
-            long address = getAddress(input);
-            inputAddress = address + input.position();
-            inputLimit = address + input.limit();
-        }
-        else if (input.hasArray()) {
+        if (input.hasArray()) {
             inputBase = input.array();
             inputAddress = ARRAY_BYTE_BASE_OFFSET + input.arrayOffset() + input.position();
             inputLimit = ARRAY_BYTE_BASE_OFFSET + input.arrayOffset() + input.limit();
@@ -68,13 +61,7 @@ public class LzoCompressor
         Object outputBase;
         long outputAddress;
         long outputLimit;
-        if (output.isDirect()) {
-            outputBase = null;
-            long address = getAddress(output);
-            outputAddress = address + output.position();
-            outputLimit = address + output.limit();
-        }
-        else if (output.hasArray()) {
+        if (output.hasArray()) {
             outputBase = output.array();
             outputAddress = ARRAY_BYTE_BASE_OFFSET + output.arrayOffset() + output.position();
             outputLimit = ARRAY_BYTE_BASE_OFFSET + output.arrayOffset() + output.limit();

--- a/src/main/java/io/airlift/compress/lzo/LzoDecompressor.java
+++ b/src/main/java/io/airlift/compress/lzo/LzoDecompressor.java
@@ -18,7 +18,6 @@ import io.airlift.compress.MalformedInputException;
 
 import java.nio.ByteBuffer;
 
-import static io.airlift.compress.lzo.UnsafeUtil.getAddress;
 import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
 
 public class LzoDecompressor
@@ -43,13 +42,7 @@ public class LzoDecompressor
         Object inputBase;
         long inputAddress;
         long inputLimit;
-        if (input.isDirect()) {
-            inputBase = null;
-            long address = getAddress(input);
-            inputAddress = address + input.position();
-            inputLimit = address + input.limit();
-        }
-        else if (input.hasArray()) {
+        if (input.hasArray()) {
             inputBase = input.array();
             inputAddress = ARRAY_BYTE_BASE_OFFSET + input.arrayOffset() + input.position();
             inputLimit = ARRAY_BYTE_BASE_OFFSET + input.arrayOffset() + input.limit();
@@ -61,13 +54,7 @@ public class LzoDecompressor
         Object outputBase;
         long outputAddress;
         long outputLimit;
-        if (output.isDirect()) {
-            outputBase = null;
-            long address = getAddress(output);
-            outputAddress = address + output.position();
-            outputLimit = address + output.limit();
-        }
-        else if (output.hasArray()) {
+        if (output.hasArray()) {
             outputBase = output.array();
             outputAddress = ARRAY_BYTE_BASE_OFFSET + output.arrayOffset() + output.position();
             outputLimit = ARRAY_BYTE_BASE_OFFSET + output.arrayOffset() + output.limit();

--- a/src/main/java/io/airlift/compress/lzo/UnsafeUtil.java
+++ b/src/main/java/io/airlift/compress/lzo/UnsafeUtil.java
@@ -17,7 +17,6 @@ import io.airlift.compress.IncompatibleJvmException;
 import sun.misc.Unsafe;
 
 import java.lang.reflect.Field;
-import java.nio.Buffer;
 import java.nio.ByteOrder;
 
 import static java.lang.String.format;
@@ -25,7 +24,6 @@ import static java.lang.String.format;
 final class UnsafeUtil
 {
     public static final Unsafe UNSAFE;
-    private static final Field ADDRESS_ACCESSOR;
 
     private UnsafeUtil() {}
 
@@ -42,25 +40,6 @@ final class UnsafeUtil
         }
         catch (Exception e) {
             throw new IncompatibleJvmException("LZO requires access to sun.misc.Unsafe");
-        }
-
-        try {
-            Field field = Buffer.class.getDeclaredField("address");
-            field.setAccessible(true);
-            ADDRESS_ACCESSOR = field;
-        }
-        catch (Exception e) {
-            throw new IncompatibleJvmException("LZO requires access to java.nio.Buffer raw address field");
-        }
-    }
-
-    public static long getAddress(Buffer buffer)
-    {
-        try {
-            return (long) ADDRESS_ACCESSOR.get(buffer);
-        }
-        catch (IllegalAccessException e) {
-            throw new RuntimeException(e);
         }
     }
 }

--- a/src/main/java/io/airlift/compress/snappy/SnappyCompressor.java
+++ b/src/main/java/io/airlift/compress/snappy/SnappyCompressor.java
@@ -17,7 +17,6 @@ import io.airlift.compress.Compressor;
 
 import java.nio.ByteBuffer;
 
-import static io.airlift.compress.snappy.UnsafeUtil.getAddress;
 import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
 
 public class SnappyCompressor
@@ -48,13 +47,7 @@ public class SnappyCompressor
         Object inputBase;
         long inputAddress;
         long inputLimit;
-        if (input.isDirect()) {
-            inputBase = null;
-            long address = getAddress(input);
-            inputAddress = address + input.position();
-            inputLimit = address + input.limit();
-        }
-        else if (input.hasArray()) {
+        if (input.hasArray()) {
             inputBase = input.array();
             inputAddress = ARRAY_BYTE_BASE_OFFSET + input.arrayOffset() + input.position();
             inputLimit = ARRAY_BYTE_BASE_OFFSET + input.arrayOffset() + input.limit();
@@ -66,13 +59,7 @@ public class SnappyCompressor
         Object outputBase;
         long outputAddress;
         long outputLimit;
-        if (output.isDirect()) {
-            outputBase = null;
-            long address = getAddress(output);
-            outputAddress = address + output.position();
-            outputLimit = address + output.limit();
-        }
-        else if (output.hasArray()) {
+        if (output.hasArray()) {
             outputBase = output.array();
             outputAddress = ARRAY_BYTE_BASE_OFFSET + output.arrayOffset() + output.position();
             outputLimit = ARRAY_BYTE_BASE_OFFSET + output.arrayOffset() + output.limit();

--- a/src/main/java/io/airlift/compress/snappy/SnappyDecompressor.java
+++ b/src/main/java/io/airlift/compress/snappy/SnappyDecompressor.java
@@ -18,7 +18,6 @@ import io.airlift.compress.MalformedInputException;
 
 import java.nio.ByteBuffer;
 
-import static io.airlift.compress.snappy.UnsafeUtil.getAddress;
 import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
 
 public class SnappyDecompressor
@@ -51,13 +50,7 @@ public class SnappyDecompressor
         Object inputBase;
         long inputAddress;
         long inputLimit;
-        if (input.isDirect()) {
-            inputBase = null;
-            long address = getAddress(input);
-            inputAddress = address + input.position();
-            inputLimit = address + input.limit();
-        }
-        else if (input.hasArray()) {
+        if (input.hasArray()) {
             inputBase = input.array();
             inputAddress = ARRAY_BYTE_BASE_OFFSET + input.arrayOffset() + input.position();
             inputLimit = ARRAY_BYTE_BASE_OFFSET + input.arrayOffset() + input.limit();
@@ -69,13 +62,7 @@ public class SnappyDecompressor
         Object outputBase;
         long outputAddress;
         long outputLimit;
-        if (output.isDirect()) {
-            outputBase = null;
-            long address = getAddress(output);
-            outputAddress = address + output.position();
-            outputLimit = address + output.limit();
-        }
-        else if (output.hasArray()) {
+        if (output.hasArray()) {
             outputBase = output.array();
             outputAddress = ARRAY_BYTE_BASE_OFFSET + output.arrayOffset() + output.position();
             outputLimit = ARRAY_BYTE_BASE_OFFSET + output.arrayOffset() + output.limit();

--- a/src/main/java/io/airlift/compress/snappy/UnsafeUtil.java
+++ b/src/main/java/io/airlift/compress/snappy/UnsafeUtil.java
@@ -17,7 +17,6 @@ import io.airlift.compress.IncompatibleJvmException;
 import sun.misc.Unsafe;
 
 import java.lang.reflect.Field;
-import java.nio.Buffer;
 import java.nio.ByteOrder;
 
 import static java.lang.String.format;
@@ -25,7 +24,6 @@ import static java.lang.String.format;
 final class UnsafeUtil
 {
     public static final Unsafe UNSAFE;
-    private static final Field ADDRESS_ACCESSOR;
 
     private UnsafeUtil() {}
 
@@ -42,25 +40,6 @@ final class UnsafeUtil
         }
         catch (Exception e) {
             throw new IncompatibleJvmException("Snappy requires access to sun.misc.Unsafe");
-        }
-
-        try {
-            Field field = Buffer.class.getDeclaredField("address");
-            field.setAccessible(true);
-            ADDRESS_ACCESSOR = field;
-        }
-        catch (Exception e) {
-            throw new IncompatibleJvmException("Snappy requires access to java.nio.Buffer raw address field");
-        }
-    }
-
-    public static long getAddress(Buffer buffer)
-    {
-        try {
-            return (long) ADDRESS_ACCESSOR.get(buffer);
-        }
-        catch (IllegalAccessException e) {
-            throw new RuntimeException(e);
         }
     }
 }

--- a/src/main/java/io/airlift/compress/zstd/UnsafeUtil.java
+++ b/src/main/java/io/airlift/compress/zstd/UnsafeUtil.java
@@ -17,7 +17,6 @@ import io.airlift.compress.IncompatibleJvmException;
 import sun.misc.Unsafe;
 
 import java.lang.reflect.Field;
-import java.nio.Buffer;
 import java.nio.ByteOrder;
 
 import static java.lang.String.format;
@@ -25,7 +24,6 @@ import static java.lang.String.format;
 final class UnsafeUtil
 {
     public static final Unsafe UNSAFE;
-    private static final Field ADDRESS_ACCESSOR;
 
     private UnsafeUtil() {}
 
@@ -42,25 +40,6 @@ final class UnsafeUtil
         }
         catch (Exception e) {
             throw new IncompatibleJvmException("Zstandard requires access to sun.misc.Unsafe");
-        }
-
-        try {
-            Field field = Buffer.class.getDeclaredField("address");
-            field.setAccessible(true);
-            ADDRESS_ACCESSOR = field;
-        }
-        catch (Exception e) {
-            throw new IncompatibleJvmException("Zstandard requires access to java.nio.Buffer raw address field");
-        }
-    }
-
-    public static long getAddress(Buffer buffer)
-    {
-        try {
-            return (long) ADDRESS_ACCESSOR.get(buffer);
-        }
-        catch (IllegalAccessException e) {
-            throw new RuntimeException(e);
         }
     }
 }

--- a/src/main/java/io/airlift/compress/zstd/ZstdCompressor.java
+++ b/src/main/java/io/airlift/compress/zstd/ZstdCompressor.java
@@ -18,7 +18,6 @@ import io.airlift.compress.Compressor;
 import java.nio.ByteBuffer;
 
 import static io.airlift.compress.zstd.Constants.MAX_BLOCK_SIZE;
-import static io.airlift.compress.zstd.UnsafeUtil.getAddress;
 import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
 
 public class ZstdCompressor
@@ -51,13 +50,7 @@ public class ZstdCompressor
         Object inputBase;
         long inputAddress;
         long inputLimit;
-        if (input.isDirect()) {
-            inputBase = null;
-            long address = getAddress(input);
-            inputAddress = address + input.position();
-            inputLimit = address + input.limit();
-        }
-        else if (input.hasArray()) {
+        if (input.hasArray()) {
             inputBase = input.array();
             inputAddress = ARRAY_BYTE_BASE_OFFSET + input.arrayOffset() + input.position();
             inputLimit = ARRAY_BYTE_BASE_OFFSET + input.arrayOffset() + input.limit();
@@ -69,13 +62,7 @@ public class ZstdCompressor
         Object outputBase;
         long outputAddress;
         long outputLimit;
-        if (output.isDirect()) {
-            outputBase = null;
-            long address = getAddress(output);
-            outputAddress = address + output.position();
-            outputLimit = address + output.limit();
-        }
-        else if (output.hasArray()) {
+        if (output.hasArray()) {
             outputBase = output.array();
             outputAddress = ARRAY_BYTE_BASE_OFFSET + output.arrayOffset() + output.position();
             outputLimit = ARRAY_BYTE_BASE_OFFSET + output.arrayOffset() + output.limit();

--- a/src/main/java/io/airlift/compress/zstd/ZstdDecompressor.java
+++ b/src/main/java/io/airlift/compress/zstd/ZstdDecompressor.java
@@ -18,7 +18,6 @@ import io.airlift.compress.MalformedInputException;
 
 import java.nio.ByteBuffer;
 
-import static io.airlift.compress.zstd.UnsafeUtil.getAddress;
 import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
 
 public class ZstdDecompressor
@@ -45,13 +44,7 @@ public class ZstdDecompressor
         Object inputBase;
         long inputAddress;
         long inputLimit;
-        if (input.isDirect()) {
-            inputBase = null;
-            long address = getAddress(input);
-            inputAddress = address + input.position();
-            inputLimit = address + input.limit();
-        }
-        else if (input.hasArray()) {
+        if (input.hasArray()) {
             inputBase = input.array();
             inputAddress = ARRAY_BYTE_BASE_OFFSET + input.arrayOffset() + input.position();
             inputLimit = ARRAY_BYTE_BASE_OFFSET + input.arrayOffset() + input.limit();
@@ -63,13 +56,7 @@ public class ZstdDecompressor
         Object outputBase;
         long outputAddress;
         long outputLimit;
-        if (output.isDirect()) {
-            outputBase = null;
-            long address = getAddress(output);
-            outputAddress = address + output.position();
-            outputLimit = address + output.limit();
-        }
-        else if (output.hasArray()) {
+        if (output.hasArray()) {
             outputBase = output.array();
             outputAddress = ARRAY_BYTE_BASE_OFFSET + output.arrayOffset() + output.position();
             outputLimit = ARRAY_BYTE_BASE_OFFSET + output.arrayOffset() + output.limit();

--- a/src/test/java/io/airlift/compress/AbstractTestCompression.java
+++ b/src/test/java/io/airlift/compress/AbstractTestCompression.java
@@ -161,63 +161,6 @@ public abstract class AbstractTestCompression
     }
 
     @Test(dataProvider = "data")
-    public void testDecompressByteBufferHeapToDirect(DataSet dataSet)
-            throws Exception
-    {
-        if (!isByteBufferSupported()) {
-            return;
-        }
-
-        byte[] uncompressedOriginal = dataSet.getUncompressed();
-
-        ByteBuffer compressed = ByteBuffer.wrap(prepareCompressedData(uncompressedOriginal));
-        ByteBuffer uncompressed = ByteBuffer.allocateDirect(uncompressedOriginal.length);
-
-        getDecompressor().decompress(compressed, uncompressed);
-        uncompressed.flip();
-
-        assertByteBufferEqual(ByteBuffer.wrap(uncompressedOriginal), uncompressed);
-    }
-
-    @Test(dataProvider = "data")
-    public void testDecompressByteBufferDirectToHeap(DataSet dataSet)
-            throws Exception
-    {
-        if (!isByteBufferSupported()) {
-            return;
-        }
-
-        byte[] uncompressedOriginal = dataSet.getUncompressed();
-
-        ByteBuffer compressed = toDirectBuffer(prepareCompressedData(uncompressedOriginal));
-        ByteBuffer uncompressed = ByteBuffer.allocate(uncompressedOriginal.length);
-
-        getDecompressor().decompress(compressed, uncompressed);
-        uncompressed.flip();
-
-        assertByteBufferEqual(ByteBuffer.wrap(uncompressedOriginal), uncompressed);
-    }
-
-    @Test(dataProvider = "data")
-    public void testDecompressByteBufferDirectToDirect(DataSet dataSet)
-            throws Exception
-    {
-        if (!isByteBufferSupported()) {
-            return;
-        }
-
-        byte[] uncompressedOriginal = dataSet.getUncompressed();
-
-        ByteBuffer compressed = toDirectBuffer(prepareCompressedData(uncompressedOriginal));
-        ByteBuffer uncompressed = ByteBuffer.allocateDirect(uncompressedOriginal.length);
-
-        getDecompressor().decompress(compressed, uncompressed);
-        uncompressed.flip();
-
-        assertByteBufferEqual(ByteBuffer.wrap(uncompressedOriginal), uncompressed);
-    }
-
-    @Test(dataProvider = "data")
     public void testCompress(DataSet testCase)
             throws Exception
     {
@@ -260,60 +203,6 @@ public abstract class AbstractTestCompression
                 compressor,
                 ByteBuffer.wrap(uncompressedOriginal),
                 ByteBuffer.allocate(compressor.maxCompressedLength(uncompressedOriginal.length)));
-    }
-
-    @Test(dataProvider = "data")
-    public void testCompressByteBufferHeapToDirect(DataSet dataSet)
-            throws Exception
-    {
-        if (!isByteBufferSupported()) {
-            return;
-        }
-
-        byte[] uncompressedOriginal = dataSet.getUncompressed();
-
-        Compressor compressor = getCompressor();
-
-        verifyCompressByteBuffer(
-                compressor,
-                ByteBuffer.wrap(uncompressedOriginal),
-                ByteBuffer.allocateDirect(compressor.maxCompressedLength(uncompressedOriginal.length)));
-    }
-
-    @Test(dataProvider = "data")
-    public void testCompressByteBufferDirectToHeap(DataSet dataSet)
-            throws Exception
-    {
-        if (!isByteBufferSupported()) {
-            return;
-        }
-
-        byte[] uncompressedOriginal = dataSet.getUncompressed();
-
-        Compressor compressor = getCompressor();
-
-        verifyCompressByteBuffer(
-                compressor,
-                toDirectBuffer(uncompressedOriginal),
-                ByteBuffer.allocate(compressor.maxCompressedLength(uncompressedOriginal.length)));
-    }
-
-    @Test(dataProvider = "data")
-    public void testCompressByteBufferDirectToDirect(DataSet dataSet)
-            throws Exception
-    {
-        if (!isByteBufferSupported()) {
-            return;
-        }
-
-        byte[] uncompressedOriginal = dataSet.getUncompressed();
-
-        Compressor compressor = getCompressor();
-
-        verifyCompressByteBuffer(
-                compressor,
-                toDirectBuffer(uncompressedOriginal),
-                ByteBuffer.allocateDirect(compressor.maxCompressedLength(uncompressedOriginal.length)));
     }
 
     private void verifyCompressByteBuffer(Compressor compressor, ByteBuffer expected, ByteBuffer compressed)
@@ -418,13 +307,6 @@ public abstract class AbstractTestCompression
         }
 
         assertEquals(left.remaining(), right.remaining(), String.format("Buffer lengths differ: %s vs %s", left.remaining(), left.remaining()));
-    }
-
-    private static ByteBuffer toDirectBuffer(byte[] data)
-    {
-        ByteBuffer direct = ByteBuffer.allocateDirect(data.length);
-        direct.put(data).flip();
-        return direct;
     }
 
     private byte[] prepareCompressedData(byte[] uncompressed)


### PR DESCRIPTION
Java 16 removed access to internal fields in the java.nio.Buffer class
to be able to operate on direct byte buffers. Since there's currently
no good alternative, we're removing support for direct buffers.

We'll revisit this later, possibly when the Foreign-Memory Access API
becomes final.

Fixes https://github.com/airlift/aircompressor/issues/125