### PR TITLE
Update hadoop-apache dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,9 +138,9 @@
         </dependency>
 
         <dependency>
-            <groupId>com.facebook.presto.hadoop</groupId>
-            <artifactId>hadoop-apache2</artifactId>
-            <version>0.3</version>
+            <groupId>io.trino.hadoop</groupId>
+            <artifactId>hadoop-apache</artifactId>
+            <version>3.2.0-12</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/test/java/io/airlift/compress/HadoopNative.java
+++ b/src/test/java/io/airlift/compress/HadoopNative.java
@@ -53,6 +53,7 @@ public final class HadoopNative
             loadLibrary("gplcompression");
             loadLibrary("lzo2");
             loadLibrary("snappy");
+            loadLibrary("zstd");
 
             // verify that all configured codec classes can be loaded
             loadAllCodecs();


### PR DESCRIPTION
Use the updated version from Trino. Among other things, it
fixes a bug when running tests in newer versions of the JDK.