### PR TITLE
Prevent JVM crash when buffer too small

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,12 @@
             <version>0.4</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/io/airlift/compress/lz4/Lz4Compressor.java
+++ b/src/main/java/io/airlift/compress/lz4/Lz4Compressor.java
@@ -20,6 +20,8 @@ import java.nio.ByteBuffer;
 
 import static io.airlift.compress.lz4.Lz4RawCompressor.MAX_TABLE_SIZE;
 import static io.airlift.compress.lz4.UnsafeUtil.getAddress;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
 import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
 
 /**
@@ -39,6 +41,9 @@ public class Lz4Compressor
     @Override
     public int compress(byte[] input, int inputOffset, int inputLength, byte[] output, int outputOffset, int maxOutputLength)
     {
+        verifyRange(input, inputOffset, inputLength);
+        verifyRange(output, outputOffset, maxOutputLength);
+
         long inputAddress = ARRAY_BYTE_BASE_OFFSET + inputOffset;
         long outputAddress = ARRAY_BYTE_BASE_OFFSET + outputOffset;
 
@@ -107,6 +112,14 @@ public class Lz4Compressor
                         table);
                 output.position(output.position() + written);
             }
+        }
+    }
+
+    private static void verifyRange(byte[] data, int offset, int length)
+    {
+        requireNonNull(data, "data is null");
+        if (offset < 0 || length < 0 || offset + length > data.length) {
+            throw new IllegalArgumentException(format("Invalid offset or length (%s, %s) in array of length %s", offset, length, data.length));
         }
     }
 }

--- a/src/main/java/io/airlift/compress/lz4/Lz4Decompressor.java
+++ b/src/main/java/io/airlift/compress/lz4/Lz4Decompressor.java
@@ -20,6 +20,8 @@ import java.nio.Buffer;
 import java.nio.ByteBuffer;
 
 import static io.airlift.compress.lz4.UnsafeUtil.getAddress;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
 import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
 
 public class Lz4Decompressor
@@ -29,6 +31,9 @@ public class Lz4Decompressor
     public int decompress(byte[] input, int inputOffset, int inputLength, byte[] output, int outputOffset, int maxOutputLength)
             throws MalformedInputException
     {
+        verifyRange(input, inputOffset, inputLength);
+        verifyRange(output, outputOffset, maxOutputLength);
+
         long inputAddress = ARRAY_BYTE_BASE_OFFSET + inputOffset;
         long inputLimit = inputAddress + inputLength;
         long outputAddress = ARRAY_BYTE_BASE_OFFSET + outputOffset;
@@ -93,6 +98,14 @@ public class Lz4Decompressor
                 int written = Lz4RawDecompressor.decompress(inputBase, inputAddress, inputLimit, outputBase, outputAddress, outputLimit);
                 output.position(output.position() + written);
             }
+        }
+    }
+
+    private static void verifyRange(byte[] data, int offset, int length)
+    {
+        requireNonNull(data, "data is null");
+        if (offset < 0 || length < 0 || offset + length > data.length) {
+            throw new IllegalArgumentException(format("Invalid offset or length (%s, %s) in array of length %s", offset, length, data.length));
         }
     }
 }

--- a/src/main/java/io/airlift/compress/lzo/LzoCompressor.java
+++ b/src/main/java/io/airlift/compress/lzo/LzoCompressor.java
@@ -20,6 +20,8 @@ import java.nio.ByteBuffer;
 
 import static io.airlift.compress.lzo.LzoRawCompressor.MAX_TABLE_SIZE;
 import static io.airlift.compress.lzo.UnsafeUtil.getAddress;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
 import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
 
 /**
@@ -39,6 +41,9 @@ public class LzoCompressor
     @Override
     public int compress(byte[] input, int inputOffset, int inputLength, byte[] output, int outputOffset, int maxOutputLength)
     {
+        verifyRange(input, inputOffset, inputLength);
+        verifyRange(output, outputOffset, maxOutputLength);
+
         long inputAddress = ARRAY_BYTE_BASE_OFFSET + inputOffset;
         long outputAddress = ARRAY_BYTE_BASE_OFFSET + outputOffset;
 
@@ -107,6 +112,14 @@ public class LzoCompressor
                         table);
                 output.position(output.position() + written);
             }
+        }
+    }
+
+    private static void verifyRange(byte[] data, int offset, int length)
+    {
+        requireNonNull(data, "data is null");
+        if (offset < 0 || length < 0 || offset + length > data.length) {
+            throw new IllegalArgumentException(format("Invalid offset or length (%s, %s) in array of length %s", offset, length, data.length));
         }
     }
 }

--- a/src/main/java/io/airlift/compress/lzo/LzoDecompressor.java
+++ b/src/main/java/io/airlift/compress/lzo/LzoDecompressor.java
@@ -20,6 +20,8 @@ import java.nio.Buffer;
 import java.nio.ByteBuffer;
 
 import static io.airlift.compress.lzo.UnsafeUtil.getAddress;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
 import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
 
 public class LzoDecompressor
@@ -29,6 +31,9 @@ public class LzoDecompressor
     public int decompress(byte[] input, int inputOffset, int inputLength, byte[] output, int outputOffset, int maxOutputLength)
             throws MalformedInputException
     {
+        verifyRange(input, inputOffset, inputLength);
+        verifyRange(output, outputOffset, maxOutputLength);
+
         long inputAddress = ARRAY_BYTE_BASE_OFFSET + inputOffset;
         long inputLimit = inputAddress + inputLength;
         long outputAddress = ARRAY_BYTE_BASE_OFFSET + outputOffset;
@@ -93,6 +98,14 @@ public class LzoDecompressor
                 int written = LzoRawDecompressor.decompress(inputBase, inputAddress, inputLimit, outputBase, outputAddress, outputLimit);
                 output.position(output.position() + written);
             }
+        }
+    }
+
+    private static void verifyRange(byte[] data, int offset, int length)
+    {
+        requireNonNull(data, "data is null");
+        if (offset < 0 || length < 0 || offset + length > data.length) {
+            throw new IllegalArgumentException(format("Invalid offset or length (%s, %s) in array of length %s", offset, length, data.length));
         }
     }
 }

--- a/src/main/java/io/airlift/compress/snappy/SnappyCompressor.java
+++ b/src/main/java/io/airlift/compress/snappy/SnappyCompressor.java
@@ -19,6 +19,8 @@ import java.nio.Buffer;
 import java.nio.ByteBuffer;
 
 import static io.airlift.compress.snappy.UnsafeUtil.getAddress;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
 import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
 
 public class SnappyCompressor
@@ -35,6 +37,9 @@ public class SnappyCompressor
     @Override
     public int compress(byte[] input, int inputOffset, int inputLength, byte[] output, int outputOffset, int maxOutputLength)
     {
+        verifyRange(input, inputOffset, inputLength);
+        verifyRange(output, outputOffset, maxOutputLength);
+
         long inputAddress = ARRAY_BYTE_BASE_OFFSET + inputOffset;
         long inputLimit = inputAddress + inputLength;
         long outputAddress = ARRAY_BYTE_BASE_OFFSET + outputOffset;
@@ -105,6 +110,14 @@ public class SnappyCompressor
                         table);
                 output.position(output.position() + written);
             }
+        }
+    }
+
+    private static void verifyRange(byte[] data, int offset, int length)
+    {
+        requireNonNull(data, "data is null");
+        if (offset < 0 || length < 0 || offset + length > data.length) {
+            throw new IllegalArgumentException(format("Invalid offset or length (%s, %s) in array of length %s", offset, length, data.length));
         }
     }
 }

--- a/src/main/java/io/airlift/compress/snappy/SnappyDecompressor.java
+++ b/src/main/java/io/airlift/compress/snappy/SnappyDecompressor.java
@@ -20,6 +20,8 @@ import java.nio.Buffer;
 import java.nio.ByteBuffer;
 
 import static io.airlift.compress.snappy.UnsafeUtil.getAddress;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
 import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
 
 public class SnappyDecompressor
@@ -37,6 +39,9 @@ public class SnappyDecompressor
     public int decompress(byte[] input, int inputOffset, int inputLength, byte[] output, int outputOffset, int maxOutputLength)
             throws MalformedInputException
     {
+        verifyRange(input, inputOffset, inputLength);
+        verifyRange(output, outputOffset, maxOutputLength);
+
         long inputAddress = ARRAY_BYTE_BASE_OFFSET + inputOffset;
         long inputLimit = inputAddress + inputLength;
         long outputAddress = ARRAY_BYTE_BASE_OFFSET + outputOffset;
@@ -101,6 +106,14 @@ public class SnappyDecompressor
                 int written = SnappyRawDecompressor.decompress(inputBase, inputAddress, inputLimit, outputBase, outputAddress, outputLimit);
                 output.position(output.position() + written);
             }
+        }
+    }
+
+    private static void verifyRange(byte[] data, int offset, int length)
+    {
+        requireNonNull(data, "data is null");
+        if (offset < 0 || length < 0 || offset + length > data.length) {
+            throw new IllegalArgumentException(format("Invalid offset or length (%s, %s) in array of length %s", offset, length, data.length));
         }
     }
 }

--- a/src/main/java/io/airlift/compress/zstd/ZstdCompressor.java
+++ b/src/main/java/io/airlift/compress/zstd/ZstdCompressor.java
@@ -20,6 +20,8 @@ import java.nio.ByteBuffer;
 
 import static io.airlift.compress.zstd.Constants.MAX_BLOCK_SIZE;
 import static io.airlift.compress.zstd.UnsafeUtil.getAddress;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
 import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
 
 public class ZstdCompressor
@@ -40,6 +42,9 @@ public class ZstdCompressor
     @Override
     public int compress(byte[] input, int inputOffset, int inputLength, byte[] output, int outputOffset, int maxOutputLength)
     {
+        verifyRange(input, inputOffset, inputLength);
+        verifyRange(output, outputOffset, maxOutputLength);
+
         long inputAddress = ARRAY_BYTE_BASE_OFFSET + inputOffset;
         long outputAddress = ARRAY_BYTE_BASE_OFFSET + outputOffset;
 
@@ -108,6 +113,14 @@ public class ZstdCompressor
                         CompressionParameters.DEFAULT_COMPRESSION_LEVEL);
                 output.position(output.position() + written);
             }
+        }
+    }
+
+    private static void verifyRange(byte[] data, int offset, int length)
+    {
+        requireNonNull(data, "data is null");
+        if (offset < 0 || length < 0 || offset + length > data.length) {
+            throw new IllegalArgumentException(format("Invalid offset or length (%s, %s) in array of length %s", offset, length, data.length));
         }
     }
 }

--- a/src/main/java/io/airlift/compress/zstd/ZstdDecompressor.java
+++ b/src/main/java/io/airlift/compress/zstd/ZstdDecompressor.java
@@ -20,6 +20,8 @@ import java.nio.Buffer;
 import java.nio.ByteBuffer;
 
 import static io.airlift.compress.zstd.UnsafeUtil.getAddress;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
 import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
 
 public class ZstdDecompressor
@@ -31,6 +33,9 @@ public class ZstdDecompressor
     public int decompress(byte[] input, int inputOffset, int inputLength, byte[] output, int outputOffset, int maxOutputLength)
             throws MalformedInputException
     {
+        verifyRange(input, inputOffset, inputLength);
+        verifyRange(output, outputOffset, maxOutputLength);
+
         long inputAddress = ARRAY_BYTE_BASE_OFFSET + inputOffset;
         long inputLimit = inputAddress + inputLength;
         long outputAddress = ARRAY_BYTE_BASE_OFFSET + outputOffset;
@@ -102,5 +107,13 @@ public class ZstdDecompressor
     {
         int baseAddress = ARRAY_BYTE_BASE_OFFSET + offset;
         return ZstdFrameDecompressor.getDecompressedSize(input, baseAddress, baseAddress + length);
+    }
+
+    private static void verifyRange(byte[] data, int offset, int length)
+    {
+        requireNonNull(data, "data is null");
+        if (offset < 0 || length < 0 || offset + length > data.length) {
+            throw new IllegalArgumentException(format("Invalid offset or length (%s, %s) in array of length %s", offset, length, data.length));
+        }
     }
 }

--- a/src/test/java/io/airlift/compress/zstd/TestZstd.java
+++ b/src/test/java/io/airlift/compress/zstd/TestZstd.java
@@ -65,7 +65,7 @@ public class TestZstd
         byte[] uncompressed = Resources.toByteArray(getClass().getClassLoader().getResource("data/zstd/with-checksum"));
 
         byte[] output = new byte[uncompressed.length + padding * 2]; // pre + post padding
-        int decompressedSize = getDecompressor().decompress(compressed, 0, compressed.length, output, padding, output.length);
+        int decompressedSize = getDecompressor().decompress(compressed, 0, compressed.length, output, padding, output.length - padding);
 
         assertByteArraysEqual(uncompressed, 0, uncompressed.length, output, padding, decompressedSize);
     }


### PR DESCRIPTION
Extracted from https://github.com/airlift/aircompressor/pull/142