### PR TITLE
Fix 24 bit out-of-bounds read

### DIFF
--- a/src/main/java/io/airlift/compress/zstd/Util.java
+++ b/src/main/java/io/airlift/compress/zstd/Util.java
@@ -74,6 +74,12 @@ final class Util
         return cycleLog;
     }
 
+    public static int get24BitLittleEndian(Object inputBase, long inputAddress)
+    {
+        return (UNSAFE.getShort(inputBase, inputAddress) & 0xFFFF)
+                | ((UNSAFE.getByte(inputBase, inputAddress + SIZE_OF_SHORT) & 0xFF) << Short.SIZE);
+    }
+
     public static void put24BitLittleEndian(Object outputBase, long outputAddress, int value)
     {
         UNSAFE.putShort(outputBase, outputAddress, (short) value);

--- a/src/main/java/io/airlift/compress/zstd/ZstdFrameDecompressor.java
+++ b/src/main/java/io/airlift/compress/zstd/ZstdFrameDecompressor.java
@@ -50,6 +50,7 @@ import static io.airlift.compress.zstd.Constants.SIZE_OF_SHORT;
 import static io.airlift.compress.zstd.Constants.TREELESS_LITERALS_BLOCK;
 import static io.airlift.compress.zstd.UnsafeUtil.UNSAFE;
 import static io.airlift.compress.zstd.Util.fail;
+import static io.airlift.compress.zstd.Util.get24BitLittleEndian;
 import static io.airlift.compress.zstd.Util.mask;
 import static io.airlift.compress.zstd.Util.verify;
 import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
@@ -158,7 +159,7 @@ class ZstdFrameDecompressor
                 verify(input + SIZE_OF_BLOCK_HEADER <= inputLimit, input, "Not enough input bytes");
 
                 // read block header
-                int header = UNSAFE.getInt(inputBase, input) & 0xFF_FFFF;
+                int header = get24BitLittleEndian(inputBase, input);
                 input += SIZE_OF_BLOCK_HEADER;
 
                 lastBlock = (header & 1) != 0;

--- a/src/test/java/io/airlift/compress/zstd/TestUtil.java
+++ b/src/test/java/io/airlift/compress/zstd/TestUtil.java
@@ -17,6 +17,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static io.airlift.compress.zstd.Util.get24BitLittleEndian;
+import static io.airlift.compress.zstd.Util.put24BitLittleEndian;
 import static org.testng.Assert.assertEquals;
 import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
 
@@ -40,5 +41,14 @@ public class TestUtil
     {
         long inputAddress = ARRAY_BYTE_BASE_OFFSET + offset;
         assertEquals(get24BitLittleEndian(bytes, inputAddress), value);
+    }
+
+    @Test(dataProvider = "test24bitIntegers")
+    public void testPut24BitLittleEndian(byte[] bytes, int offset, int value)
+    {
+        Object outputBase = new byte[bytes.length];
+        long outputAddress = ARRAY_BYTE_BASE_OFFSET + offset;
+        put24BitLittleEndian(outputBase, outputAddress, value);
+        assertEquals(outputBase, bytes);
     }
 }

--- a/src/test/java/io/airlift/compress/zstd/TestUtil.java
+++ b/src/test/java/io/airlift/compress/zstd/TestUtil.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.compress.zstd;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static io.airlift.compress.zstd.Util.get24BitLittleEndian;
+import static org.testng.Assert.assertEquals;
+import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
+
+public class TestUtil
+{
+    @DataProvider(name = "test24bitIntegers")
+    public static Object[][] test24bitIntegers()
+    {
+        return new Object[][] {
+                {new byte[]{1, 0, 0, 0}, 0, 1},
+                {new byte[]{12, -83, 0, 0}, 0, 44300},
+                {new byte[]{0, 0, -128}, 0, 8388608},
+                {new byte[]{(byte) 0xFF, (byte) 0xFF, (byte) 0xFF}, 0, 16777215},
+                {new byte[]{63, 25, 72, 0}, 0, 4725055},
+                {new byte[]{0, 0, 0, 0, 0, 0, 1, 0, 0}, 6, 1}
+        };
+    }
+
+    @Test(dataProvider = "test24bitIntegers")
+    public void testGet24BitLittleEndian(byte[] bytes, int offset, int value)
+    {
+        long inputAddress = ARRAY_BYTE_BASE_OFFSET + offset;
+        assertEquals(get24BitLittleEndian(bytes, inputAddress), value);
+    }
+}

--- a/src/test/java/io/airlift/compress/zstd/TestZstd.java
+++ b/src/test/java/io/airlift/compress/zstd/TestZstd.java
@@ -198,4 +198,14 @@ public class TestZstd
                 .isInstanceOf(MalformedInputException.class)
                 .hasMessageStartingWith("Invalid magic prefix");
     }
+
+    @Test
+    public void testDecompressIsMissingData()
+    {
+        byte[] input = new byte[]{40, -75, 47, -3, 32, 0, 1, 0};
+        byte[] output = new byte[1024];
+        assertThatThrownBy(() -> getDecompressor().decompress(input, 0, input.length, output, 0, output.length))
+                .isInstanceOf(MalformedInputException.class)
+                .hasMessageStartingWith("Not enough input bytes");
+    }
 }


### PR DESCRIPTION
Fixes an issue where the existing zstd decompressor can make an out-of-bounds unsafe read.

Currently the line
```java
verify(input + SIZE_OF_BLOCK_HEADER <= inputLimit, input, "Not enough input bytes");
```
won't catch out-of-bounds reads because it only checks for `SIZE_OF_BLOCK_HEADER`, even tho the code reads a full int.

We fix this by reading only the bytes we care about. I've mirrored the existing `put24BitLittleEndian` function with a new `get24BitLittleEndian` and added a few tests.