### PR TITLE
BZ2 cleanup

### DIFF
--- a/src/main/java/io/airlift/compress/bzip2/BZip2CompressionInputStream.java
+++ b/src/main/java/io/airlift/compress/bzip2/BZip2CompressionInputStream.java
@@ -137,7 +137,9 @@ class BZip2CompressionInputStream
         }
 
         if (needsReset) {
-            internalReset();
+            needsReset = false;
+            BufferedInputStream bufferedIn = readStreamHeader();
+            input = new CBZip2InputStream(bufferedIn);
         }
 
         int result;
@@ -164,16 +166,6 @@ class BZip2CompressionInputStream
         byte[] b = new byte[1];
         int result = this.read(b, 0, 1);
         return (result < 0) ? result : (b[0] & 0xff);
-    }
-
-    private void internalReset()
-            throws IOException
-    {
-        if (needsReset) {
-            needsReset = false;
-            BufferedInputStream bufferedIn = readStreamHeader();
-            input = new CBZip2InputStream(bufferedIn);
-        }
     }
 
     @Override

--- a/src/main/java/io/airlift/compress/bzip2/BZip2CompressionInputStream.java
+++ b/src/main/java/io/airlift/compress/bzip2/BZip2CompressionInputStream.java
@@ -13,7 +13,7 @@
  */
 package io.airlift.compress.bzip2;
 
-import org.apache.hadoop.io.compress.SplitCompressionInputStream;
+import org.apache.hadoop.io.compress.CompressionInputStream;
 
 import java.io.BufferedInputStream;
 import java.io.IOException;
@@ -24,7 +24,7 @@ import static io.airlift.compress.bzip2.BZip2Constants.HEADER;
 
 // forked from Apache Hadoop
 class BZip2CompressionInputStream
-        extends SplitCompressionInputStream
+        extends CompressionInputStream
 {
     private static final int HEADER_LEN = HEADER.length();
 
@@ -50,13 +50,7 @@ class BZip2CompressionInputStream
     public BZip2CompressionInputStream(InputStream in)
             throws IOException
     {
-        this(in, 0L, Long.MAX_VALUE);
-    }
-
-    private BZip2CompressionInputStream(InputStream in, long start, long end)
-            throws IOException
-    {
-        super(in, start, end);
+        super(in);
         needsReset = false;
         bufferedIn = new BufferedInputStream(in);
         this.startingPos = super.getPos();

--- a/src/main/java/io/airlift/compress/bzip2/BZip2CompressionInputStream.java
+++ b/src/main/java/io/airlift/compress/bzip2/BZip2CompressionInputStream.java
@@ -31,7 +31,6 @@ class BZip2CompressionInputStream
     private CBZip2InputStream input;
     private boolean needsReset;
     private BufferedInputStream bufferedIn;
-    private boolean isHeaderStripped;
     private final long startingPos;
 
     // Following state machine handles different states of compressed stream
@@ -59,9 +58,6 @@ class BZip2CompressionInputStream
             bufferedIn = readStreamHeader();
         }
         input = new CBZip2InputStream(bufferedIn);
-        if (this.isHeaderStripped) {
-            input.updateReportedByteCount(HEADER_LEN);
-        }
 
         this.updatePos(false);
     }
@@ -80,9 +76,6 @@ class BZip2CompressionInputStream
                 String header = new String(headerBytes, StandardCharsets.UTF_8);
                 if (header.compareTo(HEADER) != 0) {
                     bufferedIn.reset();
-                }
-                else {
-                    this.isHeaderStripped = true;
                 }
             }
         }

--- a/src/main/java/io/airlift/compress/bzip2/BZip2CompressionInputStream.java
+++ b/src/main/java/io/airlift/compress/bzip2/BZip2CompressionInputStream.java
@@ -25,8 +25,8 @@ import static java.util.Objects.requireNonNull;
 class BZip2CompressionInputStream
         extends CompressionInputStream
 {
-    private CBZip2InputStream input;
     private final BufferedInputStream bufferedIn;
+    private CBZip2InputStream input;
 
     public BZip2CompressionInputStream(InputStream in)
             throws IOException
@@ -44,10 +44,10 @@ class BZip2CompressionInputStream
     }
 
     @Override
-    public int read(byte[] b, int off, int len)
+    public int read(byte[] buffer, int offset, int length)
             throws IOException
     {
-        if (len == 0) {
+        if (length == 0) {
             return 0;
         }
 
@@ -60,13 +60,12 @@ class BZip2CompressionInputStream
             input = new CBZip2InputStream(bufferedIn);
         }
 
-        int result;
-        result = this.input.read(b, off, len);
+        int result = input.read(buffer, offset, length);
 
         // if the result is the end of block marker, no data was read
         if (result == CBZip2InputStream.END_OF_BLOCK) {
             // read one byte into the new block and update the position.
-            result = this.input.read(b, off, 1);
+            result = input.read(buffer, offset, 1);
         }
 
         return result;
@@ -76,9 +75,12 @@ class BZip2CompressionInputStream
     public int read()
             throws IOException
     {
-        byte[] b = new byte[1];
-        int result = this.read(b, 0, 1);
-        return (result < 0) ? result : (b[0] & 0xff);
+        byte[] buffer = new byte[1];
+        int result = read(buffer, 0, 1);
+        if (result < 0) {
+            return result;
+        }
+        return buffer[0] & 0xff;
     }
 
     @Override

--- a/src/main/java/io/airlift/compress/bzip2/BZip2CompressionInputStream.java
+++ b/src/main/java/io/airlift/compress/bzip2/BZip2CompressionInputStream.java
@@ -36,14 +36,6 @@ class BZip2CompressionInputStream
     }
 
     @Override
-    public void close()
-            throws IOException
-    {
-        input = null;
-        super.close();
-    }
-
-    @Override
     public int read(byte[] buffer, int offset, int length)
             throws IOException
     {
@@ -88,5 +80,13 @@ class BZip2CompressionInputStream
     {
         // drop the current compression stream, and new one will be created during the next read
         input = null;
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        input = null;
+        super.close();
     }
 }

--- a/src/main/java/io/airlift/compress/bzip2/BZip2CompressionInputStream.java
+++ b/src/main/java/io/airlift/compress/bzip2/BZip2CompressionInputStream.java
@@ -19,15 +19,12 @@ import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
-import static io.airlift.compress.bzip2.BZip2Constants.HEADER;
 import static java.util.Objects.requireNonNull;
 
 // forked from Apache Hadoop
 class BZip2CompressionInputStream
         extends CompressionInputStream
 {
-    private static final int HEADER_LEN = HEADER.length();
-
     private CBZip2InputStream input;
     private final BufferedInputStream bufferedIn;
 
@@ -36,16 +33,6 @@ class BZip2CompressionInputStream
     {
         super(requireNonNull(in, "in is null"));
         bufferedIn = new BufferedInputStream(in);
-    }
-
-    private void trySkipMagic()
-            throws IOException
-    {
-        // If the stream starts with `BZ`, skip it
-        bufferedIn.mark(HEADER_LEN);
-        if (bufferedIn.read() != 'B' || bufferedIn.read() != 'Z') {
-            bufferedIn.reset();
-        }
     }
 
     @Override
@@ -65,7 +52,11 @@ class BZip2CompressionInputStream
         }
 
         if (input == null) {
-            trySkipMagic();
+            // If the stream starts with `BZ`, skip it
+            bufferedIn.mark(2);
+            if (bufferedIn.read() != 'B' || bufferedIn.read() != 'Z') {
+                bufferedIn.reset();
+            }
             input = new CBZip2InputStream(bufferedIn);
         }
 

--- a/src/main/java/io/airlift/compress/bzip2/BZip2CompressionInputStream.java
+++ b/src/main/java/io/airlift/compress/bzip2/BZip2CompressionInputStream.java
@@ -209,6 +209,10 @@ class BZip2CompressionInputStream
     public int read(byte[] b, int off, int len)
             throws IOException
     {
+        if (len == 0) {
+            return 0;
+        }
+
         if (needsReset) {
             internalReset();
         }

--- a/src/main/java/io/airlift/compress/bzip2/BZip2CompressionInputStream.java
+++ b/src/main/java/io/airlift/compress/bzip2/BZip2CompressionInputStream.java
@@ -220,7 +220,7 @@ class BZip2CompressionInputStream
         }
 
         if (this.posSM == PosAdvertisementStateMachine.ADVERTISE) {
-            result = this.input.read(b, off, off + 1);
+            result = this.input.read(b, off, 1);
             // This is the precise time to update compressed stream position
             // to the client of this code.
             this.updatePos(true);

--- a/src/main/java/io/airlift/compress/bzip2/BZip2CompressionOutputStream.java
+++ b/src/main/java/io/airlift/compress/bzip2/BZip2CompressionOutputStream.java
@@ -17,9 +17,8 @@ import org.apache.hadoop.io.compress.CompressionOutputStream;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
 
-import static io.airlift.compress.bzip2.BZip2Constants.HEADER;
+import static java.util.Objects.requireNonNull;
 
 // forked from Apache Hadoop
 class BZip2CompressionOutputStream
@@ -30,19 +29,8 @@ class BZip2CompressionOutputStream
 
     public BZip2CompressionOutputStream(OutputStream out)
     {
-        super(out);
+        super(requireNonNull(out, "out is null"));
         needsReset = true;
-    }
-
-    private void writeStreamHeader()
-            throws IOException
-    {
-        if (out != null) {
-            // The compressed bzip2 stream should start with the
-            // identifying characters BZ. Caller of CBZip2OutputStream
-            // i.e. this class must write these characters.
-            out.write(HEADER.getBytes(StandardCharsets.UTF_8));
-        }
     }
 
     @Override
@@ -64,7 +52,10 @@ class BZip2CompressionOutputStream
     {
         if (needsReset) {
             needsReset = false;
-            writeStreamHeader();
+
+            // write magic
+            out.write(new byte[] {'B', 'Z'});
+
             this.output = new CBZip2OutputStream(out);
         }
     }

--- a/src/main/java/io/airlift/compress/bzip2/BZip2CompressionOutputStream.java
+++ b/src/main/java/io/airlift/compress/bzip2/BZip2CompressionOutputStream.java
@@ -33,31 +33,6 @@ class BZip2CompressionOutputStream
     }
 
     @Override
-    public void finish()
-            throws IOException
-    {
-        if (output != null) {
-            output.finish();
-            output = null;
-        }
-    }
-
-    private void openStreamIfNecessary()
-            throws IOException
-    {
-        if (output == null) {
-            initialized = true;
-            // write magic
-            out.write(new byte[] {'B', 'Z'});
-            // open new block
-            output = new CBZip2OutputStream(out);
-        }
-    }
-
-    @Override
-    public void resetState() {}
-
-    @Override
     public void write(int b)
             throws IOException
     {
@@ -74,6 +49,19 @@ class BZip2CompressionOutputStream
     }
 
     @Override
+    public void resetState() {}
+
+    @Override
+    public void finish()
+            throws IOException
+    {
+        if (output != null) {
+            output.finish();
+            output = null;
+        }
+    }
+
+    @Override
     public void close()
             throws IOException
     {
@@ -86,6 +74,18 @@ class BZip2CompressionOutputStream
         }
         finally {
             super.close();
+        }
+    }
+
+    private void openStreamIfNecessary()
+            throws IOException
+    {
+        if (output == null) {
+            initialized = true;
+            // write magic
+            out.write(new byte[] {'B', 'Z'});
+            // open new block
+            output = new CBZip2OutputStream(out);
         }
     }
 }

--- a/src/main/java/io/airlift/compress/bzip2/BZip2CompressionOutputStream.java
+++ b/src/main/java/io/airlift/compress/bzip2/BZip2CompressionOutputStream.java
@@ -50,7 +50,7 @@ class BZip2CompressionOutputStream
             // write magic
             out.write(new byte[] {'B', 'Z'});
             // open new block
-            this.output = new CBZip2OutputStream(out);
+            output = new CBZip2OutputStream(out);
         }
     }
 
@@ -62,7 +62,7 @@ class BZip2CompressionOutputStream
             throws IOException
     {
         openStreamIfNecessary();
-        this.output.write(b);
+        output.write(b);
     }
 
     @Override
@@ -70,7 +70,7 @@ class BZip2CompressionOutputStream
             throws IOException
     {
         openStreamIfNecessary();
-        this.output.write(b, off, len);
+        output.write(b, off, len);
     }
 
     @Override

--- a/src/main/java/io/airlift/compress/bzip2/BZip2Constants.java
+++ b/src/main/java/io/airlift/compress/bzip2/BZip2Constants.java
@@ -34,8 +34,6 @@ package io.airlift.compress.bzip2;
 // forked from Apache Hadoop
 final class BZip2Constants
 {
-    public static final String HEADER = "BZ";
-
     public static final int BASE_BLOCK_SIZE = 100000;
     public static final int MAX_ALPHA_SIZE = 258;
     public static final int RUN_A = 0;

--- a/src/main/java/io/airlift/compress/bzip2/CBZip2InputStream.java
+++ b/src/main/java/io/airlift/compress/bzip2/CBZip2InputStream.java
@@ -98,7 +98,7 @@ class CBZip2InputStream
     private long reportedBytesReadFromCompressedStream;
     // The following variable keep record of compressed bytes read.
     private long bytesReadFromCompressedStream;
-    private boolean lazyInitialization;
+    private boolean initialized;
 
     private final byte[] array = new byte[1];
 
@@ -179,15 +179,10 @@ class CBZip2InputStream
      * @throws NullPointerException if <tt>in == null</tt>
      */
     public CBZip2InputStream(final InputStream in)
-            throws IOException
     {
         int blockSize = 0X39; // i.e 9
         this.blockSize100k = blockSize - (int) '0';
         this.in = new BufferedInputStream(in, 1024 * 9); // >1 MB buffer
-        lazyInitialization = in.available() == 0;
-        if (!lazyInitialization) {
-            init();
-        }
     }
 
     /**
@@ -365,9 +360,9 @@ class CBZip2InputStream
             throw new IOException("stream closed");
         }
 
-        if (lazyInitialization) {
+        if (!initialized) {
             this.init();
-            this.lazyInitialization = false;
+            this.initialized = true;
         }
 
         final int hi = offs + len;

--- a/src/main/java/io/airlift/compress/bzip2/CBZip2InputStream.java
+++ b/src/main/java/io/airlift/compress/bzip2/CBZip2InputStream.java
@@ -221,21 +221,6 @@ class CBZip2InputStream
     }
 
     /**
-     * This method is called by the client of this
-     * class in case there are any corrections in
-     * the stream position.  One common example is
-     * when client of this code removes starting BZ
-     * characters from the compressed stream.
-     *
-     * @param count count bytes are added to the reported bytes
-     */
-    public void updateReportedByteCount(int count)
-    {
-        this.reportedBytesReadFromCompressedStream += count;
-        this.updateProcessedByteCount(count);
-    }
-
-    /**
      * This method reads a Byte from the compressed stream. Whenever we need to
      * read from the underlying compressed stream, this method should be called
      * instead of directly calling the read method of the underlying compressed

--- a/src/main/java/io/airlift/compress/bzip2/CBZip2InputStream.java
+++ b/src/main/java/io/airlift/compress/bzip2/CBZip2InputStream.java
@@ -182,16 +182,10 @@ class CBZip2InputStream
     public CBZip2InputStream(final InputStream in)
             throws IOException
     {
-        this(in, false);
-    }
-
-    private CBZip2InputStream(final InputStream in, boolean skipDecompression)
-            throws IOException
-    {
         int blockSize = 0X39; // i.e 9
         this.blockSize100k = blockSize - (int) '0';
         this.in = new BufferedInputStream(in, 1024 * 9); // >1 MB buffer
-        this.skipDecompression = skipDecompression;
+        this.skipDecompression = false;
         lazyInitialization = in.available() == 0;
         if (!lazyInitialization) {
             init();

--- a/src/main/java/io/airlift/compress/bzip2/CBZip2InputStream.java
+++ b/src/main/java/io/airlift/compress/bzip2/CBZip2InputStream.java
@@ -146,7 +146,6 @@ class CBZip2InputStream
 
     // used by skipToNextMarker
     private boolean skipResult;
-    private boolean skipDecompression;
 
     // Variables used by setup* methods exclusively
 
@@ -185,7 +184,6 @@ class CBZip2InputStream
         int blockSize = 0X39; // i.e 9
         this.blockSize100k = blockSize - (int) '0';
         this.in = new BufferedInputStream(in, 1024 * 9); // >1 MB buffer
-        this.skipDecompression = false;
         lazyInitialization = in.available() == 0;
         if (!lazyInitialization) {
             init();
@@ -370,11 +368,6 @@ class CBZip2InputStream
         if (lazyInitialization) {
             this.init();
             this.lazyInitialization = false;
-        }
-
-        if (skipDecompression) {
-            changeStateToProcessABlock();
-            skipDecompression = false;
         }
 
         final int hi = offs + len;


### PR DESCRIPTION
BZ2 input stream is overly complex due to unused features inherited from Hadoop.  