### PR TITLE
Fix ZSTD output stream failure when buffer is flushed early

### DIFF
--- a/src/main/java/io/airlift/compress/zstd/ZstdOutputStream.java
+++ b/src/main/java/io/airlift/compress/zstd/ZstdOutputStream.java
@@ -121,8 +121,10 @@ public class ZstdOutputStream
     private void compressIfNecessary()
             throws IOException
     {
-        // only flush when the buffer if full and the buffer is larger than the window and one additional block
-        if (uncompressedPosition == uncompressed.length && uncompressed.length - context.parameters.getWindowSize() > context.parameters.getBlockSize()) {
+        // only flush when the buffer if is max size, full, and the buffer is larger than the window and one additional block
+        if (uncompressed.length >= maxBufferSize &&
+                uncompressedPosition == uncompressed.length &&
+                uncompressed.length - context.parameters.getWindowSize() > context.parameters.getBlockSize()) {
             writeChunk(false);
         }
     }

--- a/src/test/java/io/airlift/compress/zstd/ZstdStreamCompressor.java
+++ b/src/test/java/io/airlift/compress/zstd/ZstdStreamCompressor.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 
+import static com.google.common.primitives.Ints.constrainToRange;
 import static io.airlift.compress.zstd.Constants.MAX_BLOCK_SIZE;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -47,7 +48,13 @@ public class ZstdStreamCompressor
 
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream(maxOutputLength);
         try (ZstdOutputStream zstdOutputStream = new ZstdOutputStream(byteArrayOutputStream)) {
-            zstdOutputStream.write(input, inputOffset, inputLength);
+            int writtenBytes = 0;
+            while (writtenBytes < inputLength) {
+                // limit write size to max block size, which exercises internal buffer growth and flushing logic
+                int writeSize = constrainToRange(inputLength - writtenBytes, 0, MAX_BLOCK_SIZE);
+                zstdOutputStream.write(input, inputOffset + writtenBytes, writeSize);
+                writtenBytes += writeSize;
+            }
         }
         catch (IOException e) {
             throw new UncheckedIOException(e);


### PR DESCRIPTION
In some cases, the ZSTD output stream is flushed before growing the buffer to the maximum size.  This can cause an exception when sliding the output window, and can also hurt performance as the window is copied more often.
