### PR TITLE
Add Util.readResource()

### DIFF
--- a/src/test/java/io/airlift/compress/Util.java
+++ b/src/test/java/io/airlift/compress/Util.java
@@ -13,6 +13,12 @@
  */
 package io.airlift.compress;
 
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+
 import static java.lang.String.format;
 
 public final class Util
@@ -37,5 +43,21 @@ public final class Util
             humanReadableSpeed = format("%.1fGB/s", bytesPerSecond / (1024.0f * 1024.0f * 1024.0f));
         }
         return humanReadableSpeed;
+    }
+
+    static Path getResourceAsPath(String path)
+    {
+        URL url = Util.class.getClassLoader().getResource(path);
+        Objects.requireNonNull(url, path);
+        return Path.of(url.getFile());
+    }
+
+    /**
+     * Reads data from classloader resources.
+     */
+    public static byte[] readResource(String resourcePath) throws IOException
+    {
+        Path path = getResourceAsPath(resourcePath);
+        return Files.readAllBytes(path);
     }
 }

--- a/src/test/java/io/airlift/compress/Util.java
+++ b/src/test/java/io/airlift/compress/Util.java
@@ -17,9 +17,9 @@ import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Objects;
 
 import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
 
 public final class Util
 {
@@ -48,7 +48,7 @@ public final class Util
     static Path getResourceAsPath(String path)
     {
         URL url = Util.class.getClassLoader().getResource(path);
-        Objects.requireNonNull(url, path);
+        requireNonNull(url, path);
         return Path.of(url.getFile());
     }
 

--- a/src/test/java/io/airlift/compress/lzo/TestLzopCodec.java
+++ b/src/test/java/io/airlift/compress/lzo/TestLzopCodec.java
@@ -13,7 +13,6 @@
  */
 package io.airlift.compress.lzo;
 
-import com.google.common.io.Resources;
 import io.airlift.compress.AbstractTestCompression;
 import io.airlift.compress.Compressor;
 import io.airlift.compress.Decompressor;
@@ -27,6 +26,7 @@ import org.testng.annotations.Test;
 
 import java.io.IOException;
 
+import static io.airlift.compress.Util.readResource;
 import static java.lang.String.format;
 import static org.testng.Assert.assertEquals;
 
@@ -96,8 +96,8 @@ public class TestLzopCodec
     private void assertDecompressed(String variant)
             throws IOException
     {
-        byte[] compressed = Resources.toByteArray(Resources.getResource(getClass(), format("/data/lzo/test-%s.lzo", variant)));
-        byte[] uncompressed = Resources.toByteArray(Resources.getResource(getClass(), "/data/lzo/test"));
+        byte[] compressed = readResource(format("data/lzo/test-%s.lzo", variant));
+        byte[] uncompressed = readResource("data/lzo/test");
 
         byte[] output = new byte[uncompressed.length];
         int decompressedSize = getDecompressor().decompress(compressed, 0, compressed.length, output, 0, output.length);

--- a/src/test/java/io/airlift/compress/zstd/TestZstd.java
+++ b/src/test/java/io/airlift/compress/zstd/TestZstd.java
@@ -26,8 +26,8 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Arrays;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static io.airlift.compress.Util.readResource;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testng.Assert.assertEquals;
 
 public class TestZstd

--- a/src/test/java/io/airlift/compress/zstd/TestZstdCodec.java
+++ b/src/test/java/io/airlift/compress/zstd/TestZstdCodec.java
@@ -13,7 +13,6 @@
  */
 package io.airlift.compress.zstd;
 
-import com.google.common.io.Resources;
 import io.airlift.compress.AbstractTestCompression;
 import io.airlift.compress.Compressor;
 import io.airlift.compress.Decompressor;
@@ -25,6 +24,8 @@ import org.apache.hadoop.io.compress.CompressionCodec;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+
+import static io.airlift.compress.Util.readResource;
 
 public class TestZstdCodec
         extends AbstractTestCompression
@@ -76,8 +77,8 @@ public class TestZstdCodec
     public void testConcatenatedFrames()
             throws IOException
     {
-        byte[] compressed = Resources.toByteArray(getClass().getClassLoader().getResource("data/zstd/multiple-frames.zst"));
-        byte[] uncompressed = Resources.toByteArray(getClass().getClassLoader().getResource("data/zstd/multiple-frames"));
+        byte[] compressed = readResource("data/zstd/multiple-frames.zst");
+        byte[] uncompressed = readResource("data/zstd/multiple-frames");
 
         byte[] output = new byte[uncompressed.length];
         getVerifyDecompressor().decompress(compressed, 0, compressed.length, output, 0, output.length);

--- a/src/test/java/io/airlift/compress/zstd/TestZstdCodecByteAtATime.java
+++ b/src/test/java/io/airlift/compress/zstd/TestZstdCodecByteAtATime.java
@@ -13,7 +13,6 @@
  */
 package io.airlift.compress.zstd;
 
-import com.google.common.io.Resources;
 import io.airlift.compress.AbstractTestCompression;
 import io.airlift.compress.Compressor;
 import io.airlift.compress.Decompressor;
@@ -26,6 +25,8 @@ import org.apache.hadoop.io.compress.CompressionCodec;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+
+import static io.airlift.compress.Util.readResource;
 
 public class TestZstdCodecByteAtATime
         extends AbstractTestCompression
@@ -77,8 +78,8 @@ public class TestZstdCodecByteAtATime
     public void testConcatenatedFrames()
             throws IOException
     {
-        byte[] compressed = Resources.toByteArray(getClass().getClassLoader().getResource("data/zstd/multiple-frames.zst"));
-        byte[] uncompressed = Resources.toByteArray(getClass().getClassLoader().getResource("data/zstd/multiple-frames"));
+        byte[] compressed = readResource("data/zstd/multiple-frames.zst");
+        byte[] uncompressed = readResource("data/zstd/multiple-frames");
 
         byte[] output = new byte[uncompressed.length];
         getVerifyDecompressor().decompress(compressed, 0, compressed.length, output, 0, output.length);

--- a/src/test/java/io/airlift/compress/zstd/TestZstdPartial.java
+++ b/src/test/java/io/airlift/compress/zstd/TestZstdPartial.java
@@ -20,7 +20,6 @@ import io.airlift.compress.MalformedInputException;
 import java.io.IOException;
 
 import static io.airlift.compress.Util.readResource;
-import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestZstdPartial

--- a/src/test/java/io/airlift/compress/zstd/TestZstdPartial.java
+++ b/src/test/java/io/airlift/compress/zstd/TestZstdPartial.java
@@ -13,13 +13,13 @@
  */
 package io.airlift.compress.zstd;
 
-import com.google.common.io.Resources;
 import io.airlift.compress.Compressor;
 import io.airlift.compress.Decompressor;
 import io.airlift.compress.MalformedInputException;
 
 import java.io.IOException;
 
+import static io.airlift.compress.Util.readResource;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -60,7 +60,7 @@ public class TestZstdPartial
     public void testInvalidSequenceOffset()
             throws IOException
     {
-        byte[] compressed = Resources.toByteArray(requireNonNull(getClass().getClassLoader().getResource("data/zstd/offset-before-start.zst")));
+        byte[] compressed = readResource("data/zstd/offset-before-start.zst");
         byte[] output = new byte[compressed.length * 10];
 
         assertThatThrownBy(() -> getDecompressor().decompress(compressed, 0, compressed.length, output, 0, output.length))

--- a/src/test/java/io/airlift/compress/zstd/TestZstdStream.java
+++ b/src/test/java/io/airlift/compress/zstd/TestZstdStream.java
@@ -13,7 +13,6 @@
  */
 package io.airlift.compress.zstd;
 
-import com.google.common.io.Resources;
 import io.airlift.compress.Compressor;
 import io.airlift.compress.Decompressor;
 import io.airlift.compress.MalformedInputException;
@@ -21,7 +20,7 @@ import io.airlift.compress.benchmark.DataSet;
 
 import java.io.IOException;
 
-import static java.util.Objects.requireNonNull;
+import static io.airlift.compress.Util.readResource;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestZstdStream
@@ -61,7 +60,7 @@ public class TestZstdStream
     public void testInvalidSequenceOffset()
             throws IOException
     {
-        byte[] compressed = Resources.toByteArray(requireNonNull(getClass().getClassLoader().getResource("data/zstd/offset-before-start.zst")));
+        byte[] compressed = readResource("data/zstd/offset-before-start.zst");
         byte[] output = new byte[compressed.length * 10];
 
         assertThatThrownBy(() -> getDecompressor().decompress(compressed, 0, compressed.length, output, 0, output.length))


### PR DESCRIPTION
Makes code cleaner and reduces dependency on a third-party library. (Some IDEs mark the `Resources.toByteArray()` as a warning, because it's annotated `@Beta`). 

Also makes it a little easier to later write code that reads data files as ByteBuffers. I know it's not on the radar (#146, #179), but I'd like to implement it anyway (in a separate package perhaps, or maybe suffixing all the classes with `Bb`).