### PR TITLE
Fix ZstdOutputStream corruption on double close

### DIFF
--- a/src/main/java/io/airlift/compress/zstd/ZstdOutputStream.java
+++ b/src/main/java/io/airlift/compress/zstd/ZstdOutputStream.java
@@ -133,18 +133,22 @@ public class ZstdOutputStream
     void finishWithoutClosingSource()
             throws IOException
     {
-        writeChunk(true);
-        closed = true;
+        if (!closed) {
+            writeChunk(true);
+            closed = true;
+        }
     }
 
     @Override
     public void close()
             throws IOException
     {
-        writeChunk(true);
+        if (!closed) {
+            writeChunk(true);
 
-        closed = true;
-        outputStream.close();
+            closed = true;
+            outputStream.close();
+        }
     }
 
     private void writeChunk(boolean lastChunk)


### PR DESCRIPTION
ZstdOutputStream will write out the last chunk every time close() is invoked on it, which can cause errors when the output is later decompressed. Per the java.io.Closeable interface documentation, the close() method should have no effect if invoked on an already-closed stream (which is how e.g. the core DeflaterOutputStream behaves as well), so make it a noop if the stream was already closed.