### PR TITLE
Fix out of bounds read/write in Snappy decompressor

### DIFF
--- a/src/main/java/io/airlift/compress/snappy/SnappyRawDecompressor.java
+++ b/src/main/java/io/airlift/compress/snappy/SnappyRawDecompressor.java
@@ -120,7 +120,7 @@ public final class SnappyRawDecompressor
                 // copy literal
                 long literalOutputLimit = output + literalLength;
                 if (literalOutputLimit > fastOutputLimit || input + literalLength > inputLimit - SIZE_OF_LONG) {
-                    if (literalOutputLimit > outputLimit) {
+                    if (literalOutputLimit > outputLimit || input + literalLength > inputLimit) {
                         throw new MalformedInputException(input - inputAddress);
                     }
 
@@ -153,6 +153,9 @@ public final class SnappyRawDecompressor
                     throw new MalformedInputException(input - inputAddress);
                 }
                 long matchOutputLimit = output + length;
+                if (matchOutputLimit > outputLimit) {
+                    throw new MalformedInputException(input - inputAddress);
+                }
 
                 if (output > fastOutputLimit) {
                     // slow match copy
@@ -185,10 +188,6 @@ public final class SnappyRawDecompressor
                     }
 
                     if (matchOutputLimit > fastOutputLimit) {
-                        if (matchOutputLimit > outputLimit) {
-                            throw new MalformedInputException(input - inputAddress);
-                        }
-
                         while (output < fastOutputLimit) {
                             UNSAFE.putLong(outputBase, output, UNSAFE.getLong(outputBase, matchAddress));
                             matchAddress += SIZE_OF_LONG;


### PR DESCRIPTION
In the slow literal copy path, it wasn't validating that the literal fit within the input buffer, so the call to copyMemory could read from out of bounds and cause a crash.

When copying a match, it wasn't validating that the match fit within the output buffer in both branches (slow & fast path), so the operation could write outside of the output buffer if the match length was corrupted.

Fixes #183