### PR TITLE
Fix out of bounds read/writes

### DIFF
--- a/src/main/java/io/airlift/compress/lz4/Lz4RawDecompressor.java
+++ b/src/main/java/io/airlift/compress/lz4/Lz4RawDecompressor.java
@@ -69,6 +69,9 @@ public final class Lz4RawDecompressor
                 }
                 while (value == 255 && input < inputLimit - 15);
             }
+            if (literalLength < 0) {
+                throw new MalformedInputException(input - inputAddress);
+            }
 
             // copy literal
             long literalEnd = input + literalLength;
@@ -127,6 +130,9 @@ public final class Lz4RawDecompressor
                 while (value == 255);
             }
             matchLength += MIN_MATCH; // implicit length from initial 4-byte match in encoder
+            if (matchLength < 0) {
+                throw new MalformedInputException(input - inputAddress);
+            }
 
             long matchOutputLimit = output + matchLength;
 

--- a/src/main/java/io/airlift/compress/lz4/Lz4RawDecompressor.java
+++ b/src/main/java/io/airlift/compress/lz4/Lz4RawDecompressor.java
@@ -62,6 +62,9 @@ public final class Lz4RawDecompressor
             // decode literal length
             int literalLength = token >>> 4; // top-most 4 bits of token
             if (literalLength == 0xF) {
+                if (input >= inputLimit) {
+                    throw new MalformedInputException(input - inputAddress);
+                }
                 int value;
                 do {
                     value = UNSAFE.getByte(inputBase, input++) & 0xFF;

--- a/src/main/java/io/airlift/compress/lzo/LzoRawDecompressor.java
+++ b/src/main/java/io/airlift/compress/lzo/LzoRawDecompressor.java
@@ -325,7 +325,7 @@ public final class LzoRawDecompressor
                 }
                 long literalOutputLimit = output + literalLength;
                 if (literalOutputLimit > fastOutputLimit || input + literalLength > inputLimit - SIZE_OF_LONG) {
-                    if (literalOutputLimit > outputLimit) {
+                    if (literalOutputLimit > outputLimit || input + literalLength > inputLimit) {
                         throw new MalformedInputException(input - inputAddress);
                     }
 

--- a/src/main/java/io/airlift/compress/lzo/LzoRawDecompressor.java
+++ b/src/main/java/io/airlift/compress/lzo/LzoRawDecompressor.java
@@ -248,6 +248,10 @@ public final class LzoRawDecompressor
                 }
                 firstCommand = false;
 
+                if (matchLength < 0) {
+                    throw new MalformedInputException(input - inputAddress);
+                }
+
                 // copy match
                 if (matchLength != 0) {
                     // lzo encodes match offset minus one
@@ -316,6 +320,9 @@ public final class LzoRawDecompressor
                 }
 
                 // copy literal
+                if (literalLength < 0) {
+                    throw new MalformedInputException(input - inputAddress);
+                }
                 long literalOutputLimit = output + literalLength;
                 if (literalOutputLimit > fastOutputLimit || input + literalLength > inputLimit - SIZE_OF_LONG) {
                     if (literalOutputLimit > outputLimit) {

--- a/src/main/java/io/airlift/compress/snappy/SnappyRawDecompressor.java
+++ b/src/main/java/io/airlift/compress/snappy/SnappyRawDecompressor.java
@@ -306,6 +306,9 @@ public final class SnappyRawDecompressor
                 }
             }
         }
+        if (result < 0) {
+            throw new MalformedInputException(compressedAddress, "negative compressed length");
+        }
         return new int[] {result, bytesRead};
     }
 

--- a/src/main/java/io/airlift/compress/snappy/SnappyRawDecompressor.java
+++ b/src/main/java/io/airlift/compress/snappy/SnappyRawDecompressor.java
@@ -116,6 +116,9 @@ public final class SnappyRawDecompressor
 
             if ((opCode & 0x3) == LITERAL) {
                 int literalLength = length + trailer;
+                if (literalLength < 0) {
+                    throw new MalformedInputException(input - inputAddress);
+                }
 
                 // copy literal
                 long literalOutputLimit = output + literalLength;
@@ -147,6 +150,9 @@ public final class SnappyRawDecompressor
                 // bit 8).
                 int matchOffset = entry & 0x700;
                 matchOffset += trailer;
+                if (matchOffset < 0) {
+                    throw new MalformedInputException(input - inputAddress);
+                }
 
                 long matchAddress = output - matchOffset;
                 if (matchAddress < outputAddress || output + length > outputLimit) {

--- a/src/main/java/io/airlift/compress/zstd/Huffman.java
+++ b/src/main/java/io/airlift/compress/zstd/Huffman.java
@@ -172,6 +172,8 @@ class Huffman
         long start3 = start2 + (UNSAFE.getShort(inputBase, inputAddress + 2) & 0xFFFF);
         long start4 = start3 + (UNSAFE.getShort(inputBase, inputAddress + 4) & 0xFFFF);
 
+        verify(start2 < start3 && start3 < start4 && start4 < inputLimit, inputAddress, "Input is corrupted");
+
         BitInputStream.Initializer initializer = new BitInputStream.Initializer(inputBase, start1, start2);
         initializer.initialize();
         int stream1bitsConsumed = initializer.getBitsConsumed();

--- a/src/main/java/io/airlift/compress/zstd/ZstdFrameDecompressor.java
+++ b/src/main/java/io/airlift/compress/zstd/ZstdFrameDecompressor.java
@@ -170,17 +170,17 @@ class ZstdFrameDecompressor
                 int decodedSize;
                 switch (blockType) {
                     case RAW_BLOCK:
-                        verify(inputAddress + blockSize <= inputLimit, input, "Not enough input bytes");
+                        verify(input + blockSize <= inputLimit, input, "Not enough input bytes");
                         decodedSize = decodeRawBlock(inputBase, input, blockSize, outputBase, output, outputLimit);
                         input += blockSize;
                         break;
                     case RLE_BLOCK:
-                        verify(inputAddress + 1 <= inputLimit, input, "Not enough input bytes");
+                        verify(input + 1 <= inputLimit, input, "Not enough input bytes");
                         decodedSize = decodeRleBlock(blockSize, inputBase, input, outputBase, output, outputLimit);
                         input += 1;
                         break;
                     case COMPRESSED_BLOCK:
-                        verify(inputAddress + blockSize <= inputLimit, input, "Not enough input bytes");
+                        verify(input + blockSize <= inputLimit, input, "Not enough input bytes");
                         decodedSize = decodeCompressedBlock(inputBase, input, blockSize, outputBase, output, outputLimit, frameHeader.windowSize, outputAddress);
                         input += blockSize;
                         break;

--- a/src/test/java/io/airlift/compress/lzo/TestLzo.java
+++ b/src/test/java/io/airlift/compress/lzo/TestLzo.java
@@ -17,8 +17,15 @@ import io.airlift.compress.AbstractTestCompression;
 import io.airlift.compress.Compressor;
 import io.airlift.compress.Decompressor;
 import io.airlift.compress.HadoopNative;
+import io.airlift.compress.MalformedInputException;
 import io.airlift.compress.thirdparty.HadoopLzoCompressor;
 import io.airlift.compress.thirdparty.HadoopLzoDecompressor;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestLzo
         extends AbstractTestCompression
@@ -49,5 +56,79 @@ public class TestLzo
     protected Decompressor getVerifyDecompressor()
     {
         return new HadoopLzoDecompressor();
+    }
+
+    @Test
+    public void testLiteralLengthOverflow()
+            throws IOException
+    {
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        // Command
+        buffer.write(0);
+        // Causes overflow for `literalLength`
+        buffer.write(new byte[Integer.MAX_VALUE / 255 + 1]); // ~9MB
+        buffer.write(1);
+
+        byte[] data = buffer.toByteArray();
+
+        assertThatThrownBy(() -> new LzoDecompressor().decompress(data, 0, data.length, new byte[20000], 0, 20000))
+                .isInstanceOf(MalformedInputException.class);
+    }
+
+    @Test
+    public void testMatchLengthOverflow1()
+            throws IOException
+    {
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        // Write some data so that `matchOffset` validation later passes
+        // Command
+        buffer.write(0);
+        buffer.write(new byte[66]);
+        buffer.write(8);
+        buffer.write(new byte[2107 * 8]);
+
+        // Command
+        buffer.write(0b001_0000);
+        // Causes overflow for `matchLength`
+        buffer.write(new byte[Integer.MAX_VALUE / 255 + 1]); // ~9MB
+        buffer.write(1);
+        // Trailer
+        buffer.write(0b0000_0000);
+        buffer.write(0b0000_0100);
+
+        buffer.write(new byte[10]);
+
+        byte[] data = buffer.toByteArray();
+
+        assertThatThrownBy(() -> new LzoDecompressor().decompress(data, 0, data.length, new byte[20000], 0, 20000))
+                .isInstanceOf(MalformedInputException.class);
+    }
+
+    @Test
+    public void testMatchLengthOverflow2()
+            throws IOException
+    {
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        // Write some data so that `matchOffset` validation later passes
+        // Command
+        buffer.write(0);
+        buffer.write(246);
+        buffer.write(new byte[264]);
+
+        // Command
+        buffer.write(0b0010_0000);
+        // Causes overflow for `matchLength`
+        buffer.write(new byte[Integer.MAX_VALUE / 255 + 1]); // ~9MB
+        buffer.write(1);
+        // Trailer
+        buffer.write(0b0000_0000);
+        buffer.write(0b0000_0100);
+
+        buffer.write(new byte[10]);
+
+        byte[] data = buffer.toByteArray();
+
+        assertThatThrownBy(() -> new LzoDecompressor().decompress(data, 0, data.length, new byte[20000], 0, 20000))
+                .isInstanceOf(MalformedInputException.class);
     }
 }

--- a/src/test/java/io/airlift/compress/snappy/TestSnappy.java
+++ b/src/test/java/io/airlift/compress/snappy/TestSnappy.java
@@ -67,4 +67,14 @@ public class TestSnappy
         assertThatThrownBy(() -> new SnappyDecompressor().decompress(data, 0, data.length, new byte[1024], 0, 1024))
                 .isInstanceOf(MalformedInputException.class);
     }
+
+    @Test
+    public void testNegativeLength()
+    {
+        byte[] data = {(byte) 255, (byte) 255, (byte) 255, (byte) 255, 0b0000_1000};
+
+        assertThatThrownBy(() -> SnappyDecompressor.getUncompressedLength(data, 0))
+                .isInstanceOf(MalformedInputException.class)
+                .hasMessageStartingWith("negative compressed length");
+    }
 }

--- a/src/test/java/io/airlift/compress/zstd/TestZstd.java
+++ b/src/test/java/io/airlift/compress/zstd/TestZstd.java
@@ -23,6 +23,7 @@ import io.airlift.compress.thirdparty.ZstdJniCompressor;
 import io.airlift.compress.thirdparty.ZstdJniDecompressor;
 import org.testng.annotations.Test;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Arrays;
@@ -208,5 +209,55 @@ public class TestZstd
         assertThatThrownBy(() -> getDecompressor().decompress(input, 0, input.length, output, 0, output.length))
                 .matches(e -> e instanceof MalformedInputException || e instanceof UncheckedIOException)
                 .hasMessageContaining("Not enough input bytes");
+    }
+
+    @Test
+    public void testBadHuffmanData()
+            throws IOException
+    {
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        // Magic
+        buffer.write(new byte[] {
+                (byte) 0b0010_1000,
+                (byte) 0b1011_0101,
+                (byte) 0b0010_1111,
+                (byte) 0b1111_1101,
+        });
+        // Frame header
+        buffer.write(0);
+        buffer.write(0);
+        // Block header COMPRESSED_BLOCK
+        buffer.write(new byte[] {
+                (byte) 0b1111_0100,
+                (byte) 0b0000_0000,
+                (byte) 0b0000_0000,
+        });
+        // Literals header
+        buffer.write(new byte[] {
+                // literalsBlockType COMPRESSED_LITERALS_BLOCK
+                // + literals type
+                0b0000_1010,
+                // ... header remainder
+                0b0000_0000,
+                // compressedSize
+                0b0011_1100,
+                0b0000_0000,
+        });
+        // Huffman inputSize
+        buffer.write(128);
+        // weight value
+        buffer.write(0b0001_0000);
+        // Bad start values
+        buffer.write(new byte[] {(byte) 255, (byte) 255});
+        buffer.write(new byte[] {(byte) 255, (byte) 255});
+        buffer.write(new byte[] {(byte) 255, (byte) 255});
+
+        buffer.write(new byte[10]);
+
+        byte[] data = buffer.toByteArray();
+
+        assertThatThrownBy(() -> new ZstdDecompressor().decompress(data, 0, data.length, new byte[10], 0, 10))
+                .isInstanceOf(MalformedInputException.class)
+                .hasMessageStartingWith("Input is corrupted");
     }
 }

--- a/src/test/java/io/airlift/compress/zstd/TestZstd.java
+++ b/src/test/java/io/airlift/compress/zstd/TestZstd.java
@@ -258,6 +258,6 @@ public class TestZstd
 
         assertThatThrownBy(() -> new ZstdDecompressor().decompress(data, 0, data.length, new byte[10], 0, 10))
                 .isInstanceOf(MalformedInputException.class)
-                .hasMessageStartingWith("Input is corrupted");
+                .hasMessageStartingWith("Not enough input bytes");
     }
 }


### PR DESCRIPTION
If the computed literal length was greater than Integer.MAX_VALUE, the value would overflow to a negative and cause a read before the beginning of the buffer.

Fix other assorted missing bounds checks.