### PR TITLE
Update to version 2.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.airlift</groupId>
     <artifactId>aircompressor</artifactId>
-    <version>0.28-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>aircompressor</name>


### PR DESCRIPTION
The new APIs were accidently released with the old Maven artifact-id. To avoid problems with services like Github Dependabot, we are advancing the existing 0.xx version to 2.0.1 and the new APIs will be v3.