### PR TITLE
Remove is_error invokation on function return with valid negative values

### DIFF
--- a/src/main/java/io/airlift/compress/v3/zstd/ZstdNative.java
+++ b/src/main/java/io/airlift/compress/v3/zstd/ZstdNative.java
@@ -53,6 +53,8 @@ final class ZstdNative
     // TODO should we just hardcode this to 3?
     public static final int DEFAULT_COMPRESSION_LEVEL;
 
+    private static final long CONTENT_SIZE_UNKNOWN = -1L;
+
     static {
         NativeLoader.Symbols<MethodHandles> symbols = NativeLoader.loadSymbols("zstd", MethodHandles.class, lookup());
         LINKAGE_ERROR = symbols.linkageError();
@@ -154,7 +156,7 @@ final class ZstdNative
             throw new Error("Unexpected exception", e);
         }
 
-        if (isError(result)) {
+        if (CONTENT_SIZE_UNKNOWN != result && result < 0) {
             throw new IllegalArgumentException("Unknown error occurred during decompression: " + getErrorName(result));
         }
         return result;


### PR DESCRIPTION
`ZSTD_isError()` can be used to validate many output values of many methods, and is called out for those methods in the [manual](http://facebook.github.io/zstd/zstd_manual.html). It is not called out as being usable to validate the output of `ZSTD_getFrameContentSize` in that manual, and the method itself has valid negative returns for content size unknown. 