### PR TITLE
Expose acceleration for native LZ4 and compression level for native Zstd

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ jobs:
       matrix:
         java-version:
           - 22
+          - 24
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4

--- a/src/main/java/io/airlift/compress/v3/lz4/Lz4Compressor.java
+++ b/src/main/java/io/airlift/compress/v3/lz4/Lz4Compressor.java
@@ -17,6 +17,8 @@ import io.airlift.compress.v3.Compressor;
 
 import java.lang.foreign.MemorySegment;
 
+import static io.airlift.compress.v3.lz4.Lz4Native.DEFAULT_ACCELERATION;
+
 public sealed interface Lz4Compressor
         extends Compressor
         permits Lz4JavaCompressor, Lz4NativeCompressor
@@ -25,8 +27,17 @@ public sealed interface Lz4Compressor
 
     static Lz4Compressor create()
     {
+        return create(DEFAULT_ACCELERATION);
+    }
+
+    static Lz4Compressor create(int acceleration)
+    {
         if (Lz4NativeCompressor.isEnabled()) {
-            return new Lz4NativeCompressor();
+            return new Lz4NativeCompressor(acceleration);
+        }
+
+        if (acceleration != DEFAULT_ACCELERATION) {
+            throw new IllegalArgumentException("Acceleration different from default cannot be used for non-native LZ4 compression");
         }
         return new Lz4JavaCompressor();
     }

--- a/src/main/java/io/airlift/compress/v3/lz4/Lz4Native.java
+++ b/src/main/java/io/airlift/compress/v3/lz4/Lz4Native.java
@@ -47,6 +47,7 @@ final class Lz4Native
 
     // Defined in lz4.h: https://github.com/lz4/lz4/blob/v1.9.4/lib/lz4.c#L51
     public static final int DEFAULT_ACCELERATION = 1;
+    public static final int MAX_ACCELERATION = 65537;
     public static final int STATE_SIZE;
 
     static {

--- a/src/main/java/io/airlift/compress/v3/zstd/ZstdCompressor.java
+++ b/src/main/java/io/airlift/compress/v3/zstd/ZstdCompressor.java
@@ -29,4 +29,15 @@ public interface ZstdCompressor
         }
         return new ZstdJavaCompressor();
     }
+
+    static ZstdCompressor create(int compressionLevel)
+    {
+        if (ZstdNativeCompressor.isEnabled()) {
+            return new ZstdNativeCompressor(compressionLevel);
+        }
+        if (compressionLevel != CompressionParameters.DEFAULT_COMPRESSION_LEVEL) {
+            throw new IllegalArgumentException("Compression level different from default cannot be used for non-native Zstd compressor");
+        }
+        return new ZstdJavaCompressor();
+    }
 }

--- a/src/test/java/io/airlift/compress/v3/lz4/TestLz4NativeFastest.java
+++ b/src/test/java/io/airlift/compress/v3/lz4/TestLz4NativeFastest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.compress.v3.lz4;
+
+import io.airlift.compress.v3.Compressor;
+import io.airlift.compress.v3.Decompressor;
+import io.airlift.compress.v3.thirdparty.JPountzLz4Compressor;
+import io.airlift.compress.v3.thirdparty.JPountzLz4Decompressor;
+import net.jpountz.lz4.LZ4Factory;
+
+import static io.airlift.compress.v3.lz4.Lz4Native.MAX_ACCELERATION;
+
+class TestLz4NativeFastest
+        extends AbstractTestLz4
+{
+    @Override
+    protected Compressor getCompressor()
+    {
+        return new Lz4NativeCompressor(MAX_ACCELERATION);
+    }
+
+    @Override
+    protected Decompressor getDecompressor()
+    {
+        return new Lz4NativeDecompressor();
+    }
+
+    @Override
+    protected Compressor getVerifyCompressor()
+    {
+        return new JPountzLz4Compressor(LZ4Factory.fastestInstance());
+    }
+
+    @Override
+    protected Decompressor getVerifyDecompressor()
+    {
+        return new JPountzLz4Decompressor(LZ4Factory.fastestInstance());
+    }
+}

--- a/src/test/java/io/airlift/compress/v3/zstd/TestZstdFast.java
+++ b/src/test/java/io/airlift/compress/v3/zstd/TestZstdFast.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.compress.v3.zstd;
+
+import io.airlift.compress.v3.Compressor;
+import io.airlift.compress.v3.Decompressor;
+import io.airlift.compress.v3.thirdparty.ZstdJniCompressor;
+import io.airlift.compress.v3.thirdparty.ZstdJniDecompressor;
+
+public class TestZstdFast
+        extends AbstractTestZstd
+{
+    @Override
+    protected ZstdCompressor getCompressor()
+    {
+        return new ZstdNativeCompressor(-7);
+    }
+
+    @Override
+    protected ZstdDecompressor getDecompressor()
+    {
+        return new ZstdNativeDecompressor();
+    }
+
+    @Override
+    protected Compressor getVerifyCompressor()
+    {
+        return new ZstdJniCompressor(-7);
+    }
+
+    @Override
+    protected Decompressor getVerifyDecompressor()
+    {
+        return new ZstdJniDecompressor();
+    }
+}

--- a/src/test/java/io/airlift/compress/v3/zstd/TestZstdHigh.java
+++ b/src/test/java/io/airlift/compress/v3/zstd/TestZstdHigh.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.compress.v3.zstd;
+
+import io.airlift.compress.v3.Compressor;
+import io.airlift.compress.v3.Decompressor;
+import io.airlift.compress.v3.thirdparty.ZstdJniCompressor;
+import io.airlift.compress.v3.thirdparty.ZstdJniDecompressor;
+
+public class TestZstdHigh
+        extends AbstractTestZstd
+{
+    @Override
+    protected ZstdCompressor getCompressor()
+    {
+        return new ZstdNativeCompressor(8);
+    }
+
+    @Override
+    protected ZstdDecompressor getDecompressor()
+    {
+        return new ZstdNativeDecompressor();
+    }
+
+    @Override
+    protected Compressor getVerifyCompressor()
+    {
+        return new ZstdJniCompressor(8);
+    }
+
+    @Override
+    protected Decompressor getVerifyDecompressor()
+    {
+        return new ZstdJniDecompressor();
+    }
+}


### PR DESCRIPTION
We want to use highest LZ4 acceleration level for page exchange compression which is a good tradeoff between CPU usage and compression ratio