### PR TITLE
Fix out-of-bounds read in ZstdIncrementalFrameDecompressor

### DIFF
--- a/src/main/java/io/airlift/compress/v3/zstd/ZstdIncrementalFrameDecompressor.java
+++ b/src/main/java/io/airlift/compress/v3/zstd/ZstdIncrementalFrameDecompressor.java
@@ -188,8 +188,6 @@ public class ZstdIncrementalFrameDecompressor
                     blockHeader = UNSAFE.getByte(inputBase, input) & 0xFF |
                             (UNSAFE.getByte(inputBase, input + 1) & 0xFF) << 8 |
                             (UNSAFE.getByte(inputBase, input + 2) & 0xFF) << 16;
-                    int expected = UNSAFE.getInt(inputBase, input) & 0xFF_FFFF;
-                    verify(blockHeader == expected, input, "oops");
                 }
                 input += SIZE_OF_BLOCK_HEADER;
                 state = State.READ_BLOCK;


### PR DESCRIPTION
This code branch is executed if there are less than SIZE_OF_INT bytes available, so it should not try to read an `int` then. That code apparently was only acting as assertion that the code is implemented correctly anyway.

Note that in reality this out-of-bounds read most likely would have never happened because ZstdInputStream always provides it with a large enough buffer (unless users directly used ZstdIncrementalFrameDecompressor, which they probably shouldn't).