### PR TITLE
ZstdOutputStream loses compression ratio after sliding window

### DIFF
--- a/src/main/java/io/airlift/compress/v3/zstd/BlockCompressionState.java
+++ b/src/main/java/io/airlift/compress/v3/zstd/BlockCompressionState.java
@@ -34,6 +34,7 @@ class BlockCompressionState
 
     public void slideWindow(int slideWindowSize)
     {
+        windowBaseOffset = Math.max(0, windowBaseOffset - slideWindowSize);
         for (int i = 0; i < hashTable.length; i++) {
             int newValue = hashTable[i] - slideWindowSize;
             // if new value is negative, set it to zero branchless


### PR DESCRIPTION
Hi, I found a compression ratio issue in the pure Java ZstdOutputStream streaming path.

  ## Symptom

  When compressing a large log file through ZstdOutputStream, the compressed output is much larger than both:

  - ZstdJavaCompressor one-shot compression
  - zstd-jni(https://github.com/luben/zstd-jni) streaming compression with the same effective windowLog=20

  In my benchmark, using a 200 MiB UTF-8 log file and writing to the stream in 32 KiB chunks:

   Codec                                   Ratio
  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━
   zstd-jni                                5.37%
  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━
   zstd-jni with windowLog=20              5.46%
  ─────────────────────────────────────  ────────
   Airlift ZstdOutputStream before fix    34.53%
  ─────────────────────────────────────  ────────
   Airlift ZstdOutputStream after fix      5.49%

  ## The generated frames are valid

  I also cross-checked decompression compatibility between the two implementations.

  Using the same source file:

   Compressed by               Decompressed by            Result
  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━
   zstd-jni                    zstd-jni                   OK
  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━
   zstd-jni                    Airlift ZstdInputStream    OK
  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━
   Airlift ZstdOutputStream    zstd-jni                   OK
  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━
   Airlift ZstdOutputStream    Airlift ZstdInputStream    OK

  So the issue is not frame-format compatibility. The output produced by Airlift is valid Zstandard data, but the streaming compression ratio is much worse than expected.


  ## Suspected root cause

  ZstdOutputStream slides its internal uncompressed buffer after writing full chunks:

  int slideWindowSize = uncompressedOffset - context.parameters.getWindowSize();
  context.slideWindow(slideWindowSize);

  System.arraycopy(uncompressed, slideWindowSize, uncompressed, 0,
          context.parameters.getWindowSize() + (uncompressedPosition - uncompressedOffset));
  uncompressedOffset -= slideWindowSize;
  uncompressedPosition -= slideWindowSize;

  `BlockCompressionState.slideWindow()` rebases `hashTable` and `chainTable`, but it does not rebase `windowBaseOffset`.

  However, `DoubleFastBlockCompressor` uses `windowBaseOffset` to compute `windowBaseAddress`, and then rejects matches that appear before that address:

  ```java
  final long windowBaseAddress = baseAddress + state.getWindowBaseOffset();

  if (longMatchAddress > windowBaseAddress && ...) {
      ...
  }

  After the internal buffer is slid forward, hash/chain table entries are rebased, but windowBaseOffset remains in the old coordinate system. This makes valid history look outside the active window, so many cross-
  chunk matches are discarded.

  ## Minimal fix tested

  I tested the following change:

  public void slideWindow(int slideWindowSize)
  {
      windowBaseOffset = Math.max(0, windowBaseOffset - slideWindowSize);

      for (int i = 0; i < hashTable.length; i++) {
          int newValue = hashTable[i] - slideWindowSize;
          newValue = newValue & (~(newValue >> 31));
          hashTable[i] = newValue;
      }
      ...
  }

  With this change, ZstdOutputStream output size returns to the expected range:

   Codec                                   Ratio
  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━
   Airlift ZstdOutputStream before fix    34.53%
  ─────────────────────────────────────  ────────
   Airlift ZstdOutputStream after fix      5.49%
  ─────────────────────────────────────  ────────
   zstd-jni with windowLog=20              5.46%

  ## Validation details

  Input:

  - Size: 209,715,470 bytes
  - Data type: UTF-8 log file with long lines
  - Streaming write size: 32 KiB
  - Airlift stream parameters: default level 3, windowLog=20
  - Iterations: 5

  Average results after the fix:

  airlift-stream  Avg ratio 5.49%  Avg comp ms 730.77  Avg comp MB/s 285.12
  zstd-jni        Avg ratio 5.37%  Avg comp ms 510.73  Avg comp MB/s 393.01
  zstd-jni-w20    Avg ratio 5.46%  Avg comp ms 462.57  Avg comp MB/s 432.41

  I believe windowBaseOffset should stay in the same coordinate system as the rebased hash and chain table entries during slideWindow().