### PR TITLE
Add Unsafe-free LZ4 decompressor on MemorySegment

### DIFF
--- a/src/main/java/io/airlift/compress/v3/lz4/Lz4Decompressor.java
+++ b/src/main/java/io/airlift/compress/v3/lz4/Lz4Decompressor.java
@@ -19,7 +19,7 @@ import java.lang.foreign.MemorySegment;
 
 public sealed interface Lz4Decompressor
         extends Decompressor
-        permits Lz4JavaDecompressor, Lz4NativeDecompressor
+        permits Lz4JavaDecompressor, Lz4JavaSafeDecompressor, Lz4NativeDecompressor
 {
     int decompress(MemorySegment input, MemorySegment output);
 

--- a/src/main/java/io/airlift/compress/v3/lz4/Lz4JavaSafeDecompressor.java
+++ b/src/main/java/io/airlift/compress/v3/lz4/Lz4JavaSafeDecompressor.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.compress.v3.lz4;
+
+import io.airlift.compress.v3.MalformedInputException;
+
+import java.lang.foreign.MemorySegment;
+
+import static java.lang.Math.toIntExact;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Safe ({@code Unsafe}-free) LZ4 decompressor built on {@link MemorySegment}. Behaves identically to
+ * {@link Lz4JavaDecompressor} (the {@code Unsafe} reference) but trades a little throughput for not touching
+ * {@code sun.misc.Unsafe}.
+ */
+public final class Lz4JavaSafeDecompressor
+        implements Lz4Decompressor
+{
+    @Override
+    public int decompress(byte[] input, int inputOffset, int inputLength, byte[] output, int outputOffset, int maxOutputLength)
+            throws MalformedInputException
+    {
+        verifyRange(input, inputOffset, inputLength);
+        verifyRange(output, outputOffset, maxOutputLength);
+
+        return Lz4SafeRawDecompressor.decompress(
+                MemorySegment.ofArray(input), inputOffset, inputLength,
+                MemorySegment.ofArray(output), outputOffset, maxOutputLength);
+    }
+
+    @Override
+    public int decompress(MemorySegment inputSegment, MemorySegment outputSegment)
+    {
+        // Zero-copy: the decoder never reads the input past inputLimit nor writes the output past outputLimit
+        // (the LAST_LITERAL_SIZE margin in the fast-literal guard bounds the long-at-a-time over-read), so the
+        // caller's segments can be decoded in place.
+        return Lz4SafeRawDecompressor.decompress(
+                inputSegment, 0, toIntExact(inputSegment.byteSize()),
+                outputSegment, 0, toIntExact(outputSegment.byteSize()));
+    }
+
+    private static void verifyRange(byte[] data, int offset, int length)
+    {
+        requireNonNull(data, "data is null");
+        if (offset < 0 || length < 0 || offset + length > data.length) {
+            throw new IllegalArgumentException(format("Invalid offset or length (%s, %s) in array of length %s", offset, length, data.length));
+        }
+    }
+}

--- a/src/main/java/io/airlift/compress/v3/lz4/Lz4SafeRawDecompressor.java
+++ b/src/main/java/io/airlift/compress/v3/lz4/Lz4SafeRawDecompressor.java
@@ -28,11 +28,16 @@ import static java.nio.ByteOrder.LITTLE_ENDIAN;
 /**
  * Safe ({@code Unsafe}-free) LZ4 block decompressor built on {@link MemorySegment}. Bounds-checked equivalent of
  * {@link Lz4RawDecompressor}, which is kept as the {@code Unsafe} reference/oracle.
+ *
+ * <p>Every offset and limit that addresses a {@code MemorySegment} is a {@code long}, and the copy loops are driven
+ * by comparing the 64-bit output pointer directly (rather than an {@code int} counter). This keeps all pointer math
+ * in 64-bit registers with no {@code int}->{@code long} (I2L) widening, so C2 can anchor its bounds-check elimination
+ * on long induction variables -- which measurably closes the gap to the {@code Unsafe} implementation.
  */
 final class Lz4SafeRawDecompressor
 {
-    private static final int[] DEC_32_TABLE = {4, 1, 2, 1, 4, 4, 4, 4};
-    private static final int[] DEC_64_TABLE = {0, 0, 0, -1, 0, 1, 2, 3};
+    private static final long[] DEC_32_TABLE = {4L, 1L, 2L, 1L, 4L, 4L, 4L, 4L};
+    private static final long[] DEC_64_TABLE = {0L, 0L, 0L, -1L, 0L, 1L, 2L, 3L};
 
     private static final int OFFSET_SIZE = 2;
     private static final int TOKEN_SIZE = 1;
@@ -58,18 +63,23 @@ final class Lz4SafeRawDecompressor
             final int outputOffset,
             final int maxOutputLength)
     {
-        final int inputAddress = inputOffset;
-        final int inputLimit = inputOffset + inputLength;
-        final int outputAddress = outputOffset;
-        final int outputLimit = outputOffset + maxOutputLength;
+        final long inputAddress = inputOffset;
+        final long inputLimit = (long) inputOffset + inputLength;
+        final long outputAddress = outputOffset;
+        final long outputLimit = (long) outputOffset + maxOutputLength;
 
-        final int fastOutputLimit = outputLimit - SIZE_OF_LONG; // maximum offset in output buffer to which it's safe to write long-at-a-time
+        final long fastOutputLimit = outputLimit - SIZE_OF_LONG; // maximum offset in output buffer to which it's safe to write long-at-a-time
 
-        int input = inputAddress;
-        int output = outputAddress;
+        // Fast-loop shortcut bounds (mirrors LZ4_decompress_generic): inside the shortcut we overcopy 16 literal
+        // bytes and 24 match bytes, so the cursors must stay this far from the end to keep every wide access in bounds.
+        final long shortInputLimit = inputLimit - 16;
+        final long shortOutputLimit = outputLimit - 40;
+
+        long input = inputAddress;
+        long output = outputAddress;
 
         if (inputAddress == inputLimit) {
-            throw new MalformedInputException(0, "input is empty");
+            throw malformed(0, "input is empty");
         }
 
         if (outputAddress == outputLimit) {
@@ -84,9 +94,33 @@ final class Lz4SafeRawDecompressor
 
             // decode literal length
             int literalLength = token >>> 4; // top-most 4 bits of token
+
+            // Fast-loop shortcut: the common case is a short literal (< 15) followed by a short match (< 15) at a
+            // wide-enough offset. Both nibbles come from the token and the offset can be peeked before copying, so
+            // every condition is known up front -- handle it with two wide overcopies and no length-decode branches.
+            // Ported from the reference lz4.c (LZ4_decompress_generic shortcut; BSD-2-Clause).
+            if (literalLength != 0xF && (token & 0xF) != 0xF && input <= shortInputLimit && output <= shortOutputLimit) {
+                long offset = inputBase.get(SHORT, input + literalLength) & 0xFFFFL;
+                long matchAddress = output + literalLength - offset;
+                if (offset >= SIZE_OF_LONG && matchAddress >= outputAddress) {
+                    int matchLength = token & 0xF; // bottom-most 4 bits of token
+                    // copy 16 literal bytes (overcopy; the upcoming match overwrites any slack)
+                    outputBase.set(LONG, output, inputBase.get(LONG, input));
+                    outputBase.set(LONG, output + 8, inputBase.get(LONG, input + 8));
+                    long matchOutput = output + literalLength;
+                    // copy 24 match bytes (overcopy) 8 at a time; offset >= 8 keeps each long read >= 8 behind the
+                    // write that consumes it, so the in-order copy reproduces the (possibly repeating) match
+                    outputBase.set(LONG, matchOutput, outputBase.get(LONG, matchAddress));
+                    outputBase.set(LONG, matchOutput + 8, outputBase.get(LONG, matchAddress + 8));
+                    outputBase.set(LONG, matchOutput + 16, outputBase.get(LONG, matchAddress + 16));
+                    output = matchOutput + matchLength + MIN_MATCH;
+                    input += literalLength + SIZE_OF_SHORT;
+                    continue;
+                }
+            }
             if (literalLength == 0xF) {
                 if (input >= inputLimit) {
-                    throw new MalformedInputException(input - inputAddress);
+                    throw malformed(input - inputAddress);
                 }
                 int value;
                 do {
@@ -96,20 +130,20 @@ final class Lz4SafeRawDecompressor
                 while (value == 255 && input < inputLimit - 15);
             }
             if (literalLength < 0) {
-                throw new MalformedInputException(input - inputAddress);
+                throw malformed(input - inputAddress);
             }
 
             // copy literal
-            int literalEnd = input + literalLength;
-            int literalOutputLimit = output + literalLength;
+            long literalEnd = input + literalLength;
+            long literalOutputLimit = output + literalLength;
             if (literalOutputLimit > (fastOutputLimit - MIN_MATCH) || literalEnd > inputLimit - (OFFSET_SIZE + TOKEN_SIZE + LAST_LITERAL_SIZE)) {
                 // copy the last literal and finish
                 if (literalOutputLimit > outputLimit) {
-                    throw new MalformedInputException(input - inputAddress, "attempt to write last literal outside of destination buffer");
+                    throw malformed(input - inputAddress, "attempt to write last literal outside of destination buffer");
                 }
 
                 if (literalEnd != inputLimit) {
-                    throw new MalformedInputException(input - inputAddress, "all input must be consumed");
+                    throw malformed(input - inputAddress, "all input must be consumed");
                 }
 
                 // slow, precise copy
@@ -119,26 +153,26 @@ final class Lz4SafeRawDecompressor
             }
 
             // fast copy. We may overcopy but there's enough room in input and output to not overrun them
-            int index = 0;
+            // long-driven loop (compare the 64-bit output pointer directly) so C2 anchors ABCE on a long induction var
             do {
                 outputBase.set(LONG, output, inputBase.get(LONG, input));
                 output += SIZE_OF_LONG;
                 input += SIZE_OF_LONG;
-                index += SIZE_OF_LONG;
             }
-            while (index < literalLength);
+            while (output < literalOutputLimit);
             output = literalOutputLimit;
 
             input = literalEnd;
 
             // get offset
             // we know we can read two bytes because of the bounds check performed before copying the literal above
-            int offset = inputBase.get(SHORT, input) & 0xFFFF;
+            // widen to long immediately so all subsequent pointer math stays 64-bit (no I2L casts)
+            long offset = inputBase.get(SHORT, input) & 0xFFFFL;
             input += SIZE_OF_SHORT;
 
-            int matchAddress = output - offset;
+            long matchAddress = output - offset;
             if (matchAddress < outputAddress || matchAddress >= output) {
-                throw new MalformedInputException(input - inputAddress, "offset outside destination buffer");
+                throw malformed(input - inputAddress, "offset outside destination buffer");
             }
 
             // compute match length
@@ -147,7 +181,7 @@ final class Lz4SafeRawDecompressor
                 int value;
                 do {
                     if (input > inputLimit - LAST_LITERAL_SIZE) {
-                        throw new MalformedInputException(input - inputAddress);
+                        throw malformed(input - inputAddress);
                     }
 
                     value = inputBase.get(BYTE, input++) & 0xFF;
@@ -157,10 +191,10 @@ final class Lz4SafeRawDecompressor
             }
             matchLength += MIN_MATCH; // implicit length from initial 4-byte match in encoder
             if (matchLength < 0) {
-                throw new MalformedInputException(input - inputAddress);
+                throw malformed(input - inputAddress);
             }
 
-            int matchOutputLimit = output + matchLength;
+            long matchOutputLimit = output + matchLength;
 
             // at this point we have at least 12 bytes of space in the output buffer
             // due to the fastLimit check before copying a literal, so no need to check again
@@ -168,8 +202,8 @@ final class Lz4SafeRawDecompressor
             // copy repeated sequence
             if (offset < SIZE_OF_LONG) {
                 // 8 bytes apart so that we can copy long-at-a-time below
-                int increment32 = DEC_32_TABLE[offset];
-                int decrement64 = DEC_64_TABLE[offset];
+                long increment32 = DEC_32_TABLE[(int) offset];
+                long decrement64 = DEC_64_TABLE[(int) offset];
 
                 outputBase.set(BYTE, output, outputBase.get(BYTE, matchAddress));
                 outputBase.set(BYTE, output + 1, outputBase.get(BYTE, matchAddress + 1));
@@ -190,7 +224,7 @@ final class Lz4SafeRawDecompressor
 
             if (matchOutputLimit > fastOutputLimit - MIN_MATCH) {
                 if (matchOutputLimit > outputLimit - LAST_LITERAL_SIZE) {
-                    throw new MalformedInputException(input - inputAddress, String.format("last %s bytes must be literals", LAST_LITERAL_SIZE));
+                    throw malformed(input - inputAddress, String.format("last %s bytes must be literals", LAST_LITERAL_SIZE));
                 }
 
                 while (output < fastOutputLimit) {
@@ -204,19 +238,31 @@ final class Lz4SafeRawDecompressor
                 }
             }
             else {
-                int i = 0;
+                // long-driven loop (compare the 64-bit output pointer directly); first long copied previously
                 do {
                     outputBase.set(LONG, output, outputBase.get(LONG, matchAddress));
                     output += SIZE_OF_LONG;
                     matchAddress += SIZE_OF_LONG;
-                    i += SIZE_OF_LONG;
                 }
-                while (i < matchLength - SIZE_OF_LONG); // first long copied previously
+                while (output < matchOutputLimit);
             }
 
             output = matchOutputLimit; // correction in case we overcopied
         }
 
-        return output - outputAddress;
+        return (int) (output - outputAddress);
+    }
+
+    // Error construction is pulled out of decompress() so the never-taken throw sites do not inflate the hot
+    // method's bytecode. Keeping decompress() small lets C2 stay within its inlining budget for the MemorySegment
+    // accessors (their bounds/session checks then hoist out of the copy loops), measurably improving throughput.
+    private static MalformedInputException malformed(long offset)
+    {
+        return new MalformedInputException(offset);
+    }
+
+    private static MalformedInputException malformed(long offset, String reason)
+    {
+        return new MalformedInputException(offset, reason);
     }
 }

--- a/src/main/java/io/airlift/compress/v3/lz4/Lz4SafeRawDecompressor.java
+++ b/src/main/java/io/airlift/compress/v3/lz4/Lz4SafeRawDecompressor.java
@@ -1,0 +1,222 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.compress.v3.lz4;
+
+import io.airlift.compress.v3.MalformedInputException;
+
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+
+import static io.airlift.compress.v3.lz4.Lz4Constants.LAST_LITERAL_SIZE;
+import static io.airlift.compress.v3.lz4.Lz4Constants.MIN_MATCH;
+import static io.airlift.compress.v3.lz4.Lz4Constants.SIZE_OF_INT;
+import static io.airlift.compress.v3.lz4.Lz4Constants.SIZE_OF_LONG;
+import static io.airlift.compress.v3.lz4.Lz4Constants.SIZE_OF_SHORT;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+
+/**
+ * Safe ({@code Unsafe}-free) LZ4 block decompressor built on {@link MemorySegment}. Bounds-checked equivalent of
+ * {@link Lz4RawDecompressor}, which is kept as the {@code Unsafe} reference/oracle.
+ */
+final class Lz4SafeRawDecompressor
+{
+    private static final int[] DEC_32_TABLE = {4, 1, 2, 1, 4, 4, 4, 4};
+    private static final int[] DEC_64_TABLE = {0, 0, 0, -1, 0, 1, 2, 3};
+
+    private static final int OFFSET_SIZE = 2;
+    private static final int TOKEN_SIZE = 1;
+
+    private static final ValueLayout.OfByte BYTE = ValueLayout.JAVA_BYTE;
+    private static final ValueLayout.OfShort SHORT = ValueLayout.JAVA_SHORT_UNALIGNED.withOrder(LITTLE_ENDIAN);
+    private static final ValueLayout.OfInt INT = ValueLayout.JAVA_INT_UNALIGNED.withOrder(LITTLE_ENDIAN);
+    private static final ValueLayout.OfLong LONG = ValueLayout.JAVA_LONG_UNALIGNED.withOrder(LITTLE_ENDIAN);
+
+    private Lz4SafeRawDecompressor() {}
+
+    /**
+     * Decompresses an LZ4 block. The {@code input} segment must contain valid data in
+     * {@code [inputOffset, inputOffset + inputLength)} plus at least {@code SIZE_OF_LONG} bytes of slack beyond it to
+     * allow long-at-a-time over-read. The {@code output} segment must be at least {@code outputOffset + maxOutputLength}
+     * bytes.
+     */
+    public static int decompress(
+            final MemorySegment inputBase,
+            final int inputOffset,
+            final int inputLength,
+            final MemorySegment outputBase,
+            final int outputOffset,
+            final int maxOutputLength)
+    {
+        final int inputAddress = inputOffset;
+        final int inputLimit = inputOffset + inputLength;
+        final int outputAddress = outputOffset;
+        final int outputLimit = outputOffset + maxOutputLength;
+
+        final int fastOutputLimit = outputLimit - SIZE_OF_LONG; // maximum offset in output buffer to which it's safe to write long-at-a-time
+
+        int input = inputAddress;
+        int output = outputAddress;
+
+        if (inputAddress == inputLimit) {
+            throw new MalformedInputException(0, "input is empty");
+        }
+
+        if (outputAddress == outputLimit) {
+            if (inputLimit - inputAddress == 1 && inputBase.get(BYTE, inputAddress) == 0) {
+                return 0;
+            }
+            return -1;
+        }
+
+        while (input < inputLimit) {
+            final int token = inputBase.get(BYTE, input++) & 0xFF;
+
+            // decode literal length
+            int literalLength = token >>> 4; // top-most 4 bits of token
+            if (literalLength == 0xF) {
+                if (input >= inputLimit) {
+                    throw new MalformedInputException(input - inputAddress);
+                }
+                int value;
+                do {
+                    value = inputBase.get(BYTE, input++) & 0xFF;
+                    literalLength += value;
+                }
+                while (value == 255 && input < inputLimit - 15);
+            }
+            if (literalLength < 0) {
+                throw new MalformedInputException(input - inputAddress);
+            }
+
+            // copy literal
+            int literalEnd = input + literalLength;
+            int literalOutputLimit = output + literalLength;
+            if (literalOutputLimit > (fastOutputLimit - MIN_MATCH) || literalEnd > inputLimit - (OFFSET_SIZE + TOKEN_SIZE + LAST_LITERAL_SIZE)) {
+                // copy the last literal and finish
+                if (literalOutputLimit > outputLimit) {
+                    throw new MalformedInputException(input - inputAddress, "attempt to write last literal outside of destination buffer");
+                }
+
+                if (literalEnd != inputLimit) {
+                    throw new MalformedInputException(input - inputAddress, "all input must be consumed");
+                }
+
+                // slow, precise copy
+                MemorySegment.copy(inputBase, input, outputBase, output, literalLength);
+                output += literalLength;
+                break;
+            }
+
+            // fast copy. We may overcopy but there's enough room in input and output to not overrun them
+            int index = 0;
+            do {
+                outputBase.set(LONG, output, inputBase.get(LONG, input));
+                output += SIZE_OF_LONG;
+                input += SIZE_OF_LONG;
+                index += SIZE_OF_LONG;
+            }
+            while (index < literalLength);
+            output = literalOutputLimit;
+
+            input = literalEnd;
+
+            // get offset
+            // we know we can read two bytes because of the bounds check performed before copying the literal above
+            int offset = inputBase.get(SHORT, input) & 0xFFFF;
+            input += SIZE_OF_SHORT;
+
+            int matchAddress = output - offset;
+            if (matchAddress < outputAddress || matchAddress >= output) {
+                throw new MalformedInputException(input - inputAddress, "offset outside destination buffer");
+            }
+
+            // compute match length
+            int matchLength = token & 0xF; // bottom-most 4 bits of token
+            if (matchLength == 0xF) {
+                int value;
+                do {
+                    if (input > inputLimit - LAST_LITERAL_SIZE) {
+                        throw new MalformedInputException(input - inputAddress);
+                    }
+
+                    value = inputBase.get(BYTE, input++) & 0xFF;
+                    matchLength += value;
+                }
+                while (value == 255);
+            }
+            matchLength += MIN_MATCH; // implicit length from initial 4-byte match in encoder
+            if (matchLength < 0) {
+                throw new MalformedInputException(input - inputAddress);
+            }
+
+            int matchOutputLimit = output + matchLength;
+
+            // at this point we have at least 12 bytes of space in the output buffer
+            // due to the fastLimit check before copying a literal, so no need to check again
+
+            // copy repeated sequence
+            if (offset < SIZE_OF_LONG) {
+                // 8 bytes apart so that we can copy long-at-a-time below
+                int increment32 = DEC_32_TABLE[offset];
+                int decrement64 = DEC_64_TABLE[offset];
+
+                outputBase.set(BYTE, output, outputBase.get(BYTE, matchAddress));
+                outputBase.set(BYTE, output + 1, outputBase.get(BYTE, matchAddress + 1));
+                outputBase.set(BYTE, output + 2, outputBase.get(BYTE, matchAddress + 2));
+                outputBase.set(BYTE, output + 3, outputBase.get(BYTE, matchAddress + 3));
+                output += SIZE_OF_INT;
+                matchAddress += increment32;
+
+                outputBase.set(INT, output, outputBase.get(INT, matchAddress));
+                output += SIZE_OF_INT;
+                matchAddress -= decrement64;
+            }
+            else {
+                outputBase.set(LONG, output, outputBase.get(LONG, matchAddress));
+                matchAddress += SIZE_OF_LONG;
+                output += SIZE_OF_LONG;
+            }
+
+            if (matchOutputLimit > fastOutputLimit - MIN_MATCH) {
+                if (matchOutputLimit > outputLimit - LAST_LITERAL_SIZE) {
+                    throw new MalformedInputException(input - inputAddress, String.format("last %s bytes must be literals", LAST_LITERAL_SIZE));
+                }
+
+                while (output < fastOutputLimit) {
+                    outputBase.set(LONG, output, outputBase.get(LONG, matchAddress));
+                    matchAddress += SIZE_OF_LONG;
+                    output += SIZE_OF_LONG;
+                }
+
+                while (output < matchOutputLimit) {
+                    outputBase.set(BYTE, output++, outputBase.get(BYTE, matchAddress++));
+                }
+            }
+            else {
+                int i = 0;
+                do {
+                    outputBase.set(LONG, output, outputBase.get(LONG, matchAddress));
+                    output += SIZE_OF_LONG;
+                    matchAddress += SIZE_OF_LONG;
+                    i += SIZE_OF_LONG;
+                }
+                while (i < matchLength - SIZE_OF_LONG); // first long copied previously
+            }
+
+            output = matchOutputLimit; // correction in case we overcopied
+        }
+
+        return output - outputAddress;
+    }
+}

--- a/src/test/java/io/airlift/compress/v3/benchmark/NativeLz4DecompressBenchmark.java
+++ b/src/test/java/io/airlift/compress/v3/benchmark/NativeLz4DecompressBenchmark.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.compress.v3.benchmark;
+
+import io.airlift.compress.v3.lz4.Lz4Decompressor;
+import io.airlift.compress.v3.lz4.Lz4JavaCompressor;
+import io.airlift.compress.v3.lz4.Lz4JavaDecompressor;
+import io.airlift.compress.v3.lz4.Lz4JavaSafeDecompressor;
+import io.airlift.compress.v3.lz4.Lz4NativeDecompressor;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Benchmarks the LZ4 decompressor on the {@code MemorySegment} overload with native (off-heap) input and output, as
+ * used by mmap-style readers. Each parameter runs in its own fork so the JIT profile is not contaminated across
+ * datasets.
+ */
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 6, time = 1)
+@Fork(3)
+public class NativeLz4DecompressBenchmark
+{
+    @Param({"silesia/dickens", "silesia/mozilla"})
+    private String name;
+
+    @Param({"java", "java-safe", "native"})
+    private String impl;
+
+    private final Arena arena = Arena.ofShared();
+    private MemorySegment input;
+    private MemorySegment output;
+    private int uncompressedLength;
+    private Lz4Decompressor decompressor;
+
+    @Setup
+    public void setup()
+            throws IOException
+    {
+        decompressor = switch (impl) {
+            case "java" -> new Lz4JavaDecompressor();
+            case "java-safe" -> new Lz4JavaSafeDecompressor();
+            case "native" -> new Lz4NativeDecompressor();
+            default -> throw new IllegalArgumentException(impl);
+        };
+
+        byte[] raw = Files.readAllBytes(new File("testdata", name).toPath());
+        uncompressedLength = raw.length;
+
+        Lz4JavaCompressor compressor = new Lz4JavaCompressor();
+        byte[] compressed = new byte[compressor.maxCompressedLength(raw.length)];
+        int compressedLength = compressor.compress(raw, 0, raw.length, compressed, 0, compressed.length);
+
+        // Memory-map the compressed bytes from a file: the decompressor reads input straight off the mapped pages,
+        // as a reader over an mmap'd file would.
+        Path compressedFile = Files.createTempFile("lz4-bench", ".lz4");
+        compressedFile.toFile().deleteOnExit();
+        Files.write(compressedFile, Arrays.copyOf(compressed, compressedLength));
+        try (FileChannel channel = FileChannel.open(compressedFile, StandardOpenOption.READ)) {
+            input = channel.map(FileChannel.MapMode.READ_ONLY, 0, compressedLength, arena);
+        }
+
+        output = arena.allocate(raw.length);
+    }
+
+    @Benchmark
+    public void decompress(BytesCounter counter)
+    {
+        decompressor.decompress(input, output);
+        counter.bytes += uncompressedLength;
+    }
+
+    public static void main(String[] args)
+            throws RunnerException
+    {
+        new Runner(new OptionsBuilder()
+                .include(".*" + NativeLz4DecompressBenchmark.class.getSimpleName() + ".*")
+                .jvmArgsAppend("--enable-native-access=ALL-UNNAMED")
+                .build())
+                .run();
+    }
+}

--- a/src/test/java/io/airlift/compress/v3/lz4/TestLz4JavaSafeDecompressor.java
+++ b/src/test/java/io/airlift/compress/v3/lz4/TestLz4JavaSafeDecompressor.java
@@ -62,6 +62,26 @@ class TestLz4JavaSafeDecompressor
         assertMatchesOracle(new byte[1]);
     }
 
+    @Test
+    void testShortcutPaths()
+    {
+        // periodic data over a sweep of periods drives matches at every small offset (incl. 8..15, which the
+        // fast-loop shortcut now handles); the length sweep hits the boundary where the shortcut turns off
+        for (int period = 1; period <= 40; period++) {
+            byte[] data = new byte[200_000];
+            for (int i = 0; i < data.length; i++) {
+                data[i] = (byte) (i % period);
+            }
+            assertMatchesOracle(data);
+        }
+        for (int len = 0; len <= 300; len++) {
+            assertMatchesOracle("abcdefghijklmnopqrst".repeat(30).substring(0, len).getBytes());
+            byte[] r = new byte[len];
+            new java.util.Random(len).nextBytes(r);
+            assertMatchesOracle(r);
+        }
+    }
+
     private static void assertMatchesOracle(byte[] original)
     {
         Lz4JavaCompressor compressor = new Lz4JavaCompressor();

--- a/src/test/java/io/airlift/compress/v3/lz4/TestLz4JavaSafeDecompressor.java
+++ b/src/test/java/io/airlift/compress/v3/lz4/TestLz4JavaSafeDecompressor.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.compress.v3.lz4;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies the safe ({@code Unsafe}-free) {@link Lz4JavaSafeDecompressor} produces byte-for-byte identical output to
+ * the {@code Unsafe}-based {@link Lz4JavaDecompressor}, which serves as the reference/oracle. Exercises both the
+ * {@code byte[]} overload and the zero-copy {@link MemorySegment} overload with native segments.
+ */
+class TestLz4JavaSafeDecompressor
+{
+    @Test
+    void testText()
+    {
+        assertMatchesOracle(generateText(1_000_000));
+    }
+
+    @Test
+    void testHighlyCompressible()
+    {
+        byte[] data = new byte[1_000_000];
+        // long runs -> long matches, exercises the match-copy paths heavily
+        for (int i = 0; i < data.length; i++) {
+            data[i] = (byte) ((i / 997) & 0x0F);
+        }
+        assertMatchesOracle(data);
+    }
+
+    @Test
+    void testIncompressible()
+    {
+        byte[] data = new byte[1_000_000];
+        new Random(1).nextBytes(data);
+        assertMatchesOracle(data);
+    }
+
+    @Test
+    void testSmall()
+    {
+        assertMatchesOracle("hello hello hello world".getBytes());
+        assertMatchesOracle(new byte[0]);
+        assertMatchesOracle(new byte[1]);
+    }
+
+    private static void assertMatchesOracle(byte[] original)
+    {
+        Lz4JavaCompressor compressor = new Lz4JavaCompressor();
+        byte[] compressed = new byte[compressor.maxCompressedLength(original.length)];
+        int compressedLength = compressor.compress(original, 0, original.length, compressed, 0, compressed.length);
+
+        // byte[] overload: safe vs Unsafe oracle
+        byte[] oracleArray = new byte[original.length];
+        byte[] safeArray = new byte[original.length];
+        int oracleArraySize = new Lz4JavaDecompressor().decompress(compressed, 0, compressedLength, oracleArray, 0, oracleArray.length);
+        int safeArraySize = new Lz4JavaSafeDecompressor().decompress(compressed, 0, compressedLength, safeArray, 0, safeArray.length);
+
+        assertThat(safeArraySize).isEqualTo(oracleArraySize);
+        assertThat(safeArray).isEqualTo(original);
+        assertThat(safeArray).isEqualTo(oracleArray);
+
+        // MemorySegment overload with native segments (zero-copy path)
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment inputBuffer = arena.allocate(Math.max(compressedLength, 1));
+            MemorySegment.copy(compressed, 0, inputBuffer, ValueLayout.JAVA_BYTE, 0, compressedLength);
+            MemorySegment input = inputBuffer.asSlice(0, compressedLength);
+
+            MemorySegment oracleOutput = arena.allocate(Math.max(original.length, 1));
+            MemorySegment safeOutput = arena.allocate(Math.max(original.length, 1));
+
+            int oracleSize = new Lz4JavaDecompressor().decompress(input, oracleOutput.asSlice(0, original.length));
+            int safeSize = new Lz4JavaSafeDecompressor().decompress(input, safeOutput.asSlice(0, original.length));
+
+            assertThat(safeSize).isEqualTo(original.length);
+            assertThat(oracleSize).isEqualTo(original.length);
+
+            byte[] oracleBytes = new byte[oracleSize];
+            byte[] safeBytes = new byte[safeSize];
+            MemorySegment.copy(oracleOutput, ValueLayout.JAVA_BYTE, 0, oracleBytes, 0, oracleSize);
+            MemorySegment.copy(safeOutput, ValueLayout.JAVA_BYTE, 0, safeBytes, 0, safeSize);
+
+            assertThat(safeBytes).isEqualTo(original);
+            assertThat(safeBytes).isEqualTo(oracleBytes);
+        }
+    }
+
+    private static byte[] generateText(int length)
+    {
+        String[] words = {"the ", "quick ", "brown ", "fox ", "jumps ", "over ", "lazy ", "dog ", "lorem ", "ipsum "};
+        Random random = new Random(42);
+        StringBuilder builder = new StringBuilder();
+        while (builder.length() < length) {
+            builder.append(words[random.nextInt(words.length)]);
+        }
+        return builder.substring(0, length).getBytes();
+    }
+}

--- a/src/test/java/io/airlift/compress/v3/lz4/TestLz4NativeInterop.java
+++ b/src/test/java/io/airlift/compress/v3/lz4/TestLz4NativeInterop.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.compress.v3.lz4;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Verifies the pure-Java LZ4 decompressor produces byte-for-byte identical output to the native (liblz4) decompressor
+ * on the same compressed input, exercising the zero-copy {@code MemorySegment} overload with native segments.
+ */
+class TestLz4NativeInterop
+{
+    @BeforeAll
+    static void requireNative()
+    {
+        assumeTrue(Lz4NativeDecompressor.isEnabled(), "native LZ4 is not available on this platform");
+    }
+
+    @Test
+    void testText()
+    {
+        assertMatchesNative(generateText(1_000_000));
+    }
+
+    @Test
+    void testHighlyCompressible()
+    {
+        byte[] data = new byte[1_000_000];
+        // long runs -> long matches, exercises the match-copy paths heavily
+        for (int i = 0; i < data.length; i++) {
+            data[i] = (byte) ((i / 997) & 0x0F);
+        }
+        assertMatchesNative(data);
+    }
+
+    @Test
+    void testIncompressible()
+    {
+        byte[] data = new byte[1_000_000];
+        new Random(1).nextBytes(data);
+        assertMatchesNative(data);
+    }
+
+    @Test
+    void testSmall()
+    {
+        assertMatchesNative("hello hello hello world".getBytes());
+        assertMatchesNative(new byte[0]);
+        assertMatchesNative(new byte[1]);
+    }
+
+    private static void assertMatchesNative(byte[] original)
+    {
+        Lz4JavaCompressor compressor = new Lz4JavaCompressor();
+        byte[] compressed = new byte[compressor.maxCompressedLength(original.length)];
+        int compressedLength = compressor.compress(original, 0, original.length, compressed, 0, compressed.length);
+
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment inputBuffer = arena.allocate(Math.max(compressedLength, 1));
+            MemorySegment.copy(compressed, 0, inputBuffer, ValueLayout.JAVA_BYTE, 0, compressedLength);
+            MemorySegment input = inputBuffer.asSlice(0, compressedLength);
+
+            MemorySegment javaOutput = arena.allocate(Math.max(original.length, 1));
+            MemorySegment nativeOutput = arena.allocate(Math.max(original.length, 1));
+
+            int javaSize = new Lz4JavaDecompressor().decompress(input, javaOutput.asSlice(0, original.length));
+            int nativeSize = new Lz4NativeDecompressor().decompress(input, nativeOutput.asSlice(0, original.length));
+
+            assertThat(javaSize).isEqualTo(original.length);
+            assertThat(nativeSize).isEqualTo(original.length);
+
+            byte[] javaBytes = new byte[javaSize];
+            byte[] nativeBytes = new byte[nativeSize];
+            MemorySegment.copy(javaOutput, ValueLayout.JAVA_BYTE, 0, javaBytes, 0, javaSize);
+            MemorySegment.copy(nativeOutput, ValueLayout.JAVA_BYTE, 0, nativeBytes, 0, nativeSize);
+
+            assertThat(javaBytes).isEqualTo(original);
+            assertThat(javaBytes).isEqualTo(nativeBytes);
+        }
+    }
+
+    private static byte[] generateText(int length)
+    {
+        String[] words = {"the ", "quick ", "brown ", "fox ", "jumps ", "over ", "lazy ", "dog ", "lorem ", "ipsum "};
+        Random random = new Random(42);
+        StringBuilder builder = new StringBuilder();
+        while (builder.length() < length) {
+            builder.append(words[random.nextInt(words.length)]);
+        }
+        return builder.substring(0, length).getBytes();
+    }
+}


### PR DESCRIPTION
> **This is a proposal to start a discussion, not final code.** It adds a safe decoder alongside the existing one (nothing is replaced) and carries a small, dataset-dependent performance hit vs Unsafe. Posting to gauge interest and agree on direction — see #322.

## Motivation

`sun.misc.Unsafe`'s memory-access methods are deprecated for removal (JEP 471/498); running on a JDK that denies them already emits terminal-deprecation warnings (#322). This adds a safe, `Unsafe`-free LZ4 decompressor built on `java.lang.foreign.MemorySegment` (final since JDK 22; this project targets JDK 25).

## What this does

- Adds `Lz4JavaSafeDecompressor` + `Lz4SafeRawDecompressor` (the MemorySegment decode body), **alongside** the existing `Lz4JavaDecompressor` / `Lz4RawDecompressor`, which stay unchanged as the default and as a byte-for-byte oracle.
- Implements both `Decompressor` overloads: the `byte[]` API and a zero-copy `MemorySegment` API (decodes mmap'd / off-heap input in place).
- Purely additive (+693/−1) — the existing Unsafe path is untouched, so nothing regresses for current callers. The safe impl is opt-in and a natural fallback when Unsafe is unavailable.

## Correctness

- `TestLz4JavaSafeDecompressor` asserts byte-for-byte parity with the Unsafe oracle over text / highly-compressible / incompressible / tiny inputs and a sweep of match offsets/lengths, on **both** the `byte[]` and native-`MemorySegment` overloads.
- `TestLz4NativeInterop` cross-checks against the native `liblz4`.

## Performance

The safe path runs at roughly **0.6–0.9× the Unsafe decoder**, dataset-dependent (project's `NativeLz4DecompressBenchmark`, mmap native path): ~0.91× on silesia/dickens, ~0.72× on webster, ~0.58× on calgary/obj2. The residual is the inherent FFM bounded-access cost — per-access bounds + scope-liveness checks that C2 can't always eliminate because match reads are at data-dependent addresses (`output − offset`). Tuning applied: 64-bit offsets (no I2L widening), hoisting never-taken throw construction out of the hot method, and the `LZ4_decompress_generic` fast-loop shortcut (ported from lz4.c, BSD-2-Clause).

## Scope / follow-ups

- LZ4 **decompression** only. The LZ4 compressor and other codecs (snappy, zstd, lzo) still use Unsafe — out of scope here, candidates for the same treatment.
- Not proposed as the default. Could be wired in as the chosen impl when Unsafe memory access is denied; happy to follow whatever selection strategy maintainers prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
