### PR TITLE
Add LZ4 frame format compressor and decompressor

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ compression and decompression.
 The native implementation of LZ4 is provided by `Lz4NativeCompressor` and `Lz4NativeDecompressor`.
 The Java implementation is provided by `Lz4JavaCompressor` and `Lz4JavaDecompressor`.
 
+The [LZ4 frame format](https://github.com/lz4/lz4/blob/dev/doc/lz4_Frame_format.md), which is the
+format produced by the `lz4` command line tool, is supported by `Lz4FrameNativeCompressor` and
+`Lz4FrameNativeDecompressor` (native), and `Lz4FrameJavaCompressor` and `Lz4FrameJavaDecompressor`
+(Java). The framing itself is always performed in Java; the implementations differ only in the
+raw block codec used to compress and decompress the block contents.
+
 ## [Snappy](https://google.github.io/snappy/)
 Snappy is not as fast as LZ4, but provides a guarantee on memory usage that makes it a good
 choice for extremely resource-limited environments (e.g. embedded systems like a network 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,28 @@ try (XxHash64Hasher hasher = XxHash64Hasher.create()) {
 }
 ```
 
+## [XXHash32](https://xxhash.com/)
+XXHash32 is the 32-bit variant of the XXHash family. It is provided primarily for formats that
+require a 32-bit hash, such as the LZ4 frame format. For general-purpose hashing, prefer XXHash3
+or XXHash64.
+
+The native implementation is provided by `XxHash32NativeHasher` and the Java implementation
+is provided by `XxHash32JavaHasher`. The `XxHash32Hasher` interface provides static methods
+that automatically select the best available implementation.
+
+```java
+// One-shot hashing
+int hash = XxHash32Hasher.hash(data);
+int hash = XxHash32Hasher.hash(data, seed);
+
+// Streaming hashing
+try (XxHash32Hasher hasher = XxHash32Hasher.create()) {
+    hasher.update(chunk1);
+    hasher.update(chunk2);
+    int hash = hasher.digest();
+}
+```
+
 # Hadoop Compression
 
 In addition to the raw block encoders, there are implementations of the

--- a/src/main/java/io/airlift/compress/v3/lz4/Lz4FrameCompression.java
+++ b/src/main/java/io/airlift/compress/v3/lz4/Lz4FrameCompression.java
@@ -1,0 +1,371 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.compress.v3.lz4;
+
+import io.airlift.compress.v3.MalformedInputException;
+import io.airlift.compress.v3.xxhash.XxHash32Hasher;
+
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+
+import static io.airlift.compress.v3.lz4.Lz4FrameFormat.BD_4MB;
+import static io.airlift.compress.v3.lz4.Lz4FrameFormat.BD_RESERVED_MASK;
+import static io.airlift.compress.v3.lz4.Lz4FrameFormat.BLOCK_MAX_SIZE_4MB;
+import static io.airlift.compress.v3.lz4.Lz4FrameFormat.BLOCK_SIZE_MASK;
+import static io.airlift.compress.v3.lz4.Lz4FrameFormat.END_MARK_SIZE;
+import static io.airlift.compress.v3.lz4.Lz4FrameFormat.FLG_BLOCK_CHECKSUM;
+import static io.airlift.compress.v3.lz4.Lz4FrameFormat.FLG_BLOCK_INDEPENDENCE;
+import static io.airlift.compress.v3.lz4.Lz4FrameFormat.FLG_CONTENT_CHECKSUM;
+import static io.airlift.compress.v3.lz4.Lz4FrameFormat.FLG_CONTENT_SIZE;
+import static io.airlift.compress.v3.lz4.Lz4FrameFormat.FLG_DICTIONARY_ID;
+import static io.airlift.compress.v3.lz4.Lz4FrameFormat.FLG_RESERVED_MASK;
+import static io.airlift.compress.v3.lz4.Lz4FrameFormat.FLG_VERSION;
+import static io.airlift.compress.v3.lz4.Lz4FrameFormat.HEADER_SIZE;
+import static io.airlift.compress.v3.lz4.Lz4FrameFormat.MAGIC;
+import static io.airlift.compress.v3.lz4.Lz4FrameFormat.SKIPPABLE_MAGIC;
+import static io.airlift.compress.v3.lz4.Lz4FrameFormat.SKIPPABLE_MAGIC_MASK;
+import static io.airlift.compress.v3.lz4.Lz4FrameFormat.UNCOMPRESSED_BLOCK_FLAG;
+import static io.airlift.compress.v3.lz4.Lz4FrameFormat.blockMaximumSize;
+import static java.lang.Math.toIntExact;
+import static java.lang.String.format;
+import static java.lang.foreign.ValueLayout.JAVA_BYTE;
+import static java.lang.foreign.ValueLayout.JAVA_INT_UNALIGNED;
+import static java.lang.foreign.ValueLayout.JAVA_LONG_UNALIGNED;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Shared implementation of the LZ4 frame format used by both the Java and native frame codecs.
+ * <p>
+ * The framing (magic number, frame descriptor, the mandatory xxHash32 header checksum, block
+ * framing and end mark) is handled here in Java, while the per-block compression is delegated to a
+ * raw LZ4 block {@link Lz4Compressor}/{@link Lz4Decompressor}. This keeps the two implementations
+ * identical apart from the block codec, and means the native codec only relies on the raw block
+ * functions of the native library rather than its frame API.
+ * <p>
+ * Frames are always written with independent blocks so they can be decoded block-by-block.
+ * Decompression handles multiple concatenated frames, skipping any skippable frames. Frames using
+ * linked blocks or a dictionary are rejected, as they cannot be decoded block-by-block.
+ */
+final class Lz4FrameCompression
+{
+    private static final ValueLayout.OfInt INT_LE = JAVA_INT_UNALIGNED.withOrder(LITTLE_ENDIAN);
+    private static final ValueLayout.OfLong LONG_LE = JAVA_LONG_UNALIGNED.withOrder(LITTLE_ENDIAN);
+
+    private Lz4FrameCompression() {}
+
+    public static int maxCompressedLength(int uncompressedSize)
+    {
+        if (uncompressedSize < 0) {
+            throw new IllegalArgumentException("uncompressedSize is negative: " + uncompressedSize);
+        }
+        // header + end mark + the uncompressed data itself (worst case: every block stored uncompressed)
+        // plus a 4-byte block header for each block. Computed in long to avoid int overflow.
+        long blocks = ((long) uncompressedSize + BLOCK_MAX_SIZE_4MB - 1) / BLOCK_MAX_SIZE_4MB;
+        long maxLength = HEADER_SIZE + END_MARK_SIZE + (long) uncompressedSize + (Integer.BYTES * blocks);
+        if (maxLength > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException("Maximum compressed length exceeds Integer.MAX_VALUE for uncompressedSize: " + uncompressedSize);
+        }
+        return toIntExact(maxLength);
+    }
+
+    public static int compress(Lz4Compressor blockCompressor, byte[] input, int inputOffset, int inputLength, byte[] output, int outputOffset, int maxOutputLength)
+    {
+        verifyRange(input, inputOffset, inputLength);
+        verifyRange(output, outputOffset, maxOutputLength);
+
+        MemorySegment inputSegment = MemorySegment.ofArray(input).asSlice(inputOffset, inputLength);
+        MemorySegment outputSegment = MemorySegment.ofArray(output).asSlice(outputOffset, maxOutputLength);
+        return compress(blockCompressor, inputSegment, outputSegment);
+    }
+
+    public static int compress(Lz4Compressor blockCompressor, MemorySegment input, MemorySegment output)
+    {
+        long inputLength = input.byteSize();
+        long outputLimit = output.byteSize();
+
+        // frame header
+        long position = writeInt(output, 0, outputLimit, MAGIC);
+        position = writeByte(output, position, outputLimit, (byte) (FLG_VERSION | FLG_BLOCK_INDEPENDENCE));
+        position = writeByte(output, position, outputLimit, (byte) BD_4MB);
+        int headerChecksum = (XxHash32Hasher.hash(output.asSlice(position - 2, 2)) >>> 8) & 0xFF;
+        position = writeByte(output, position, outputLimit, (byte) headerChecksum);
+
+        // data blocks
+        byte[] scratch = new byte[blockCompressor.maxCompressedLength(Math.clamp(inputLength, 1, BLOCK_MAX_SIZE_4MB))];
+        MemorySegment scratchSegment = MemorySegment.ofArray(scratch);
+        long inputPosition = 0;
+        while (inputPosition < inputLength) {
+            int blockLength = toIntExact(Math.min(BLOCK_MAX_SIZE_4MB, inputLength - inputPosition));
+            MemorySegment block = input.asSlice(inputPosition, blockLength);
+            int compressedLength = blockCompressor.compress(block, scratchSegment);
+
+            if (compressedLength < blockLength) {
+                position = writeInt(output, position, outputLimit, compressedLength);
+                ensureCapacity(position, compressedLength, outputLimit);
+                MemorySegment.copy(scratchSegment, 0, output, position, compressedLength);
+                position += compressedLength;
+            }
+            else {
+                // storing the block uncompressed is smaller (or no larger) than the compressed form
+                position = writeInt(output, position, outputLimit, blockLength | UNCOMPRESSED_BLOCK_FLAG);
+                ensureCapacity(position, blockLength, outputLimit);
+                MemorySegment.copy(input, inputPosition, output, position, blockLength);
+                position += blockLength;
+            }
+            inputPosition += blockLength;
+        }
+
+        // end mark
+        position = writeInt(output, position, outputLimit, 0);
+        return toIntExact(position);
+    }
+
+    public static int decompress(Lz4Decompressor blockDecompressor, byte[] input, int inputOffset, int inputLength, byte[] output, int outputOffset, int maxOutputLength)
+            throws MalformedInputException
+    {
+        verifyRange(input, inputOffset, inputLength);
+        verifyRange(output, outputOffset, maxOutputLength);
+
+        MemorySegment inputSegment = MemorySegment.ofArray(input).asSlice(inputOffset, inputLength);
+        MemorySegment outputSegment = MemorySegment.ofArray(output).asSlice(outputOffset, maxOutputLength);
+        return decompress(blockDecompressor, inputSegment, outputSegment);
+    }
+
+    public static int decompress(Lz4Decompressor blockDecompressor, MemorySegment input, MemorySegment output)
+            throws MalformedInputException
+    {
+        long inputLength = input.byteSize();
+
+        if (inputLength < HEADER_SIZE) {
+            throw new MalformedInputException(0, "Input is too short to be an LZ4 frame");
+        }
+
+        // the input may hold several concatenated frames, all of which are decoded
+        long position = 0;
+        long outputPosition = 0;
+        while (position < inputLength) {
+            if (position + Integer.BYTES > inputLength) {
+                throw new MalformedInputException(position, "Truncated LZ4 frame: incomplete magic number");
+            }
+            int magic = input.get(INT_LE, position);
+            if (magic == MAGIC) {
+                Frame frame = decompressFrame(blockDecompressor, input, position, output, outputPosition);
+                position = frame.inputPosition();
+                outputPosition = frame.outputPosition();
+            }
+            else if ((magic & SKIPPABLE_MAGIC_MASK) == SKIPPABLE_MAGIC) {
+                position = skipFrame(input, position);
+            }
+            else {
+                throw new MalformedInputException(position, "Invalid LZ4 frame magic number");
+            }
+        }
+
+        return toIntExact(outputPosition);
+    }
+
+    /**
+     * Position in the input and output after a single frame has been decoded.
+     */
+    private record Frame(long inputPosition, long outputPosition) {}
+
+    private static Frame decompressFrame(Lz4Decompressor blockDecompressor, MemorySegment input, long frameStart, MemorySegment output, long outputStart)
+            throws MalformedInputException
+    {
+        long inputLength = input.byteSize();
+        long outputLimit = output.byteSize();
+
+        // frame descriptor: FLG, BD, optional content size, then the header checksum
+        long descriptorStart = frameStart + Integer.BYTES;
+        if (descriptorStart + 2 > inputLength) {
+            throw new MalformedInputException(descriptorStart, "Truncated LZ4 frame header");
+        }
+        int flg = input.get(JAVA_BYTE, descriptorStart) & 0xFF;
+        int bd = input.get(JAVA_BYTE, descriptorStart + 1) & 0xFF;
+
+        int version = (flg >>> 6) & 0b11;
+        if (version != 1) {
+            throw new MalformedInputException(descriptorStart, "Unsupported LZ4 frame version: " + version);
+        }
+        // reserved bits are for future extensions, so a frame setting them cannot be decoded safely
+        if ((flg & FLG_RESERVED_MASK) != 0 || (bd & BD_RESERVED_MASK) != 0) {
+            throw new MalformedInputException(descriptorStart, "Corrupt LZ4 frame: reserved bits in the frame descriptor must be zero");
+        }
+
+        boolean blockIndependence = (flg & FLG_BLOCK_INDEPENDENCE) != 0;
+        boolean blockChecksum = (flg & FLG_BLOCK_CHECKSUM) != 0;
+        boolean contentSize = (flg & FLG_CONTENT_SIZE) != 0;
+        boolean contentChecksum = (flg & FLG_CONTENT_CHECKSUM) != 0;
+        boolean dictionaryId = (flg & FLG_DICTIONARY_ID) != 0;
+
+        // linked blocks reference data from previous blocks, so they cannot be decoded block-by-block
+        if (!blockIndependence) {
+            throw new MalformedInputException(descriptorStart, "LZ4 frames with linked blocks are not supported");
+        }
+        // there is no way to supply a dictionary through this API, and the blocks cannot be decoded without it
+        if (dictionaryId) {
+            throw new MalformedInputException(descriptorStart, "LZ4 frames with a dictionary are not supported");
+        }
+
+        int blockMaximumSize = blockMaximumSize((bd >>> 4) & 0b111);
+        if (blockMaximumSize < 0) {
+            throw new MalformedInputException(descriptorStart + 1, "Invalid LZ4 frame block maximum size");
+        }
+
+        long position = descriptorStart + 2;
+        if (position + (contentSize ? Long.BYTES : 0) + 1 > inputLength) {
+            throw new MalformedInputException(position, "Truncated LZ4 frame header");
+        }
+        long expectedContentSize = -1;
+        if (contentSize) {
+            expectedContentSize = input.get(LONG_LE, position);
+            position += Long.BYTES;
+        }
+
+        int expectedHeaderChecksum = input.get(JAVA_BYTE, position) & 0xFF;
+        int actualHeaderChecksum = (XxHash32Hasher.hash(input.asSlice(descriptorStart, position - descriptorStart)) >>> 8) & 0xFF;
+        if (expectedHeaderChecksum != actualHeaderChecksum) {
+            throw new MalformedInputException(position, "Corrupt LZ4 frame: invalid header checksum");
+        }
+        position++;
+
+        long outputPosition = outputStart;
+        while (true) {
+            if (position + Integer.BYTES > inputLength) {
+                throw new MalformedInputException(position, "Truncated LZ4 frame: missing block size");
+            }
+            int blockHeader = input.get(INT_LE, position);
+            position += Integer.BYTES;
+            if (blockHeader == 0) {
+                // end mark
+                break;
+            }
+
+            boolean uncompressed = (blockHeader & UNCOMPRESSED_BLOCK_FLAG) != 0;
+            int blockLength = blockHeader & BLOCK_SIZE_MASK;
+            if (blockLength > blockMaximumSize || position + blockLength > inputLength) {
+                throw new MalformedInputException(position, "Truncated LZ4 frame: block extends past end of input");
+            }
+
+            if (uncompressed) {
+                if (outputPosition + blockLength > outputLimit) {
+                    throw new MalformedInputException(outputPosition, "Output buffer too small");
+                }
+                MemorySegment.copy(input, position, output, outputPosition, blockLength);
+                outputPosition += blockLength;
+            }
+            else {
+                MemorySegment block = input.asSlice(position, blockLength);
+                MemorySegment blockOutput = output.asSlice(outputPosition, outputLimit - outputPosition);
+                int decompressedLength = blockDecompressor.decompress(block, blockOutput);
+                if (decompressedLength < 0) {
+                    throw new MalformedInputException(outputPosition, "Output buffer too small");
+                }
+                if (decompressedLength > blockMaximumSize) {
+                    throw new MalformedInputException(position, "Corrupt LZ4 frame: decompressed block exceeds maximum block size");
+                }
+                outputPosition += decompressedLength;
+            }
+
+            // the block checksum covers the block data as stored (position still points at its start)
+            if (blockChecksum) {
+                long blockChecksumPosition = position + blockLength;
+                if (blockChecksumPosition + Integer.BYTES > inputLength) {
+                    throw new MalformedInputException(blockChecksumPosition, "Truncated LZ4 frame: missing block checksum");
+                }
+                int expectedBlockChecksum = input.get(INT_LE, blockChecksumPosition);
+                int actualBlockChecksum = XxHash32Hasher.hash(input.asSlice(position, blockLength));
+                if (expectedBlockChecksum != actualBlockChecksum) {
+                    throw new MalformedInputException(blockChecksumPosition, "Corrupt LZ4 frame: invalid block checksum");
+                }
+            }
+
+            position += blockLength;
+            if (blockChecksum) {
+                position += Integer.BYTES;
+            }
+        }
+
+        // the content size and checksum cover the content of this frame only
+        long contentLength = outputPosition - outputStart;
+        if (contentChecksum) {
+            if (position + Integer.BYTES > inputLength) {
+                throw new MalformedInputException(position, "Truncated LZ4 frame: missing content checksum");
+            }
+            int expectedContentChecksum = input.get(INT_LE, position);
+            int actualContentChecksum = XxHash32Hasher.hash(output.asSlice(outputStart, contentLength));
+            if (expectedContentChecksum != actualContentChecksum) {
+                throw new MalformedInputException(position, "Corrupt LZ4 frame: invalid content checksum");
+            }
+            position += Integer.BYTES;
+        }
+
+        if (contentSize && contentLength != expectedContentSize) {
+            throw new MalformedInputException(position, "Corrupt LZ4 frame: content size does not match frame header");
+        }
+
+        return new Frame(position, outputPosition);
+    }
+
+    /**
+     * Skips a skippable frame, which holds user defined data that is not part of the decoded content.
+     */
+    private static long skipFrame(MemorySegment input, long frameStart)
+            throws MalformedInputException
+    {
+        long inputLength = input.byteSize();
+
+        long sizePosition = frameStart + Integer.BYTES;
+        if (sizePosition + Integer.BYTES > inputLength) {
+            throw new MalformedInputException(sizePosition, "Truncated LZ4 skippable frame: missing frame size");
+        }
+        long frameSize = Integer.toUnsignedLong(input.get(INT_LE, sizePosition));
+
+        long frameEnd = sizePosition + Integer.BYTES + frameSize;
+        if (frameEnd > inputLength) {
+            throw new MalformedInputException(sizePosition, "Truncated LZ4 skippable frame");
+        }
+        return frameEnd;
+    }
+
+    private static long writeInt(MemorySegment output, long position, long limit, int value)
+    {
+        ensureCapacity(position, Integer.BYTES, limit);
+        output.set(INT_LE, position, value);
+        return position + Integer.BYTES;
+    }
+
+    private static long writeByte(MemorySegment output, long position, long limit, byte value)
+    {
+        ensureCapacity(position, 1, limit);
+        output.set(JAVA_BYTE, position, value);
+        return position + 1;
+    }
+
+    private static void ensureCapacity(long position, long length, long limit)
+    {
+        if (position + length > limit) {
+            throw new IllegalArgumentException("Output buffer too small");
+        }
+    }
+
+    private static void verifyRange(byte[] data, int offset, int length)
+    {
+        requireNonNull(data, "data is null");
+        if (offset < 0 || length < 0 || offset + length > data.length) {
+            throw new IllegalArgumentException(format("Invalid offset or length (%s, %s) in array of length %s", offset, length, data.length));
+        }
+    }
+}

--- a/src/main/java/io/airlift/compress/v3/lz4/Lz4FrameCompressor.java
+++ b/src/main/java/io/airlift/compress/v3/lz4/Lz4FrameCompressor.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.compress.v3.lz4;
+
+import io.airlift.compress.v3.Compressor;
+
+/**
+ * Compresses data into the standard LZ4 frame format (as produced by the {@code lz4} command line tool),
+ * as opposed to the raw LZ4 block format handled by {@link Lz4Compressor}.
+ */
+public interface Lz4FrameCompressor
+        extends Compressor
+{
+    static Lz4FrameCompressor create()
+    {
+        if (Lz4FrameNativeCompressor.isEnabled()) {
+            return new Lz4FrameNativeCompressor();
+        }
+        return new Lz4FrameJavaCompressor();
+    }
+}

--- a/src/main/java/io/airlift/compress/v3/lz4/Lz4FrameDecompressor.java
+++ b/src/main/java/io/airlift/compress/v3/lz4/Lz4FrameDecompressor.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.compress.v3.lz4;
+
+import io.airlift.compress.v3.Decompressor;
+
+/**
+ * Decompresses data in the standard LZ4 frame format (as produced by the {@code lz4} command line tool),
+ * as opposed to the raw LZ4 block format handled by {@link Lz4Decompressor}.
+ */
+public interface Lz4FrameDecompressor
+        extends Decompressor
+{
+    static Lz4FrameDecompressor create()
+    {
+        if (Lz4FrameNativeDecompressor.isEnabled()) {
+            return new Lz4FrameNativeDecompressor();
+        }
+        return new Lz4FrameJavaDecompressor();
+    }
+}

--- a/src/main/java/io/airlift/compress/v3/lz4/Lz4FrameFormat.java
+++ b/src/main/java/io/airlift/compress/v3/lz4/Lz4FrameFormat.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.compress.v3.lz4;
+
+/**
+ * Constants describing the LZ4 frame format.
+ * See <a href="https://github.com/lz4/lz4/blob/dev/doc/lz4_Frame_format.md">lz4 frame format specification</a>.
+ */
+final class Lz4FrameFormat
+{
+    private Lz4FrameFormat() {}
+
+    // Frame magic number, stored little-endian
+    public static final int MAGIC = 0x184D2204;
+
+    // Skippable frames use a magic number of 0x184D2A5X, followed by a 4 byte frame size
+    public static final int SKIPPABLE_MAGIC = 0x184D2A50;
+    public static final int SKIPPABLE_MAGIC_MASK = 0xFFFF_FFF0;
+
+    // Frame descriptor FLG byte: version number is always 01 in bits 7-6
+    public static final int FLG_VERSION = 0b01 << 6;
+    public static final int FLG_BLOCK_INDEPENDENCE = 1 << 5;
+    public static final int FLG_BLOCK_CHECKSUM = 1 << 4;
+    public static final int FLG_CONTENT_SIZE = 1 << 3;
+    public static final int FLG_CONTENT_CHECKSUM = 1 << 2;
+    public static final int FLG_DICTIONARY_ID = 1;
+
+    // Reserved bits, which the specification requires to be zero: FLG bit 1, and BD bit 7 and bits 3-0
+    public static final int FLG_RESERVED_MASK = 0b0000_0010;
+    public static final int BD_RESERVED_MASK = 0b1000_1111;
+
+    // Frame descriptor BD byte: block maximum size id (4MB) is stored in bits 6-4
+    public static final int BD_4MB = 7 << 4;
+    public static final int BLOCK_MAX_SIZE_4MB = 4 * 1024 * 1024;
+
+    // magic number (4 bytes) + FLG (1 byte) + BD (1 byte) + header checksum (1 byte)
+    public static final int HEADER_SIZE = 7;
+    // end mark is a block size of zero (4 bytes)
+    public static final int END_MARK_SIZE = 4;
+
+    // Highest bit of the block size indicates that the block is stored uncompressed
+    public static final int UNCOMPRESSED_BLOCK_FLAG = 0x8000_0000;
+    public static final int BLOCK_SIZE_MASK = 0x7FFF_FFFF;
+
+    /**
+     * Maximum size of a data block for the given block maximum size id (4-7), or -1 if the id is invalid.
+     */
+    public static int blockMaximumSize(int blockSizeId)
+    {
+        return switch (blockSizeId) {
+            case 4 -> 64 * 1024;
+            case 5 -> 256 * 1024;
+            case 6 -> 1024 * 1024;
+            case 7 -> 4 * 1024 * 1024;
+            default -> -1;
+        };
+    }
+}

--- a/src/main/java/io/airlift/compress/v3/lz4/Lz4FrameJavaCompressor.java
+++ b/src/main/java/io/airlift/compress/v3/lz4/Lz4FrameJavaCompressor.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.compress.v3.lz4;
+
+import java.lang.foreign.MemorySegment;
+
+/**
+ * Pure-Java compressor that produces the standard LZ4 frame format, delegating per-block
+ * compression to the Java LZ4 block compressor. Frames are emitted with independent blocks.
+ * This class is not thread-safe.
+ */
+public final class Lz4FrameJavaCompressor
+        implements Lz4FrameCompressor
+{
+    private final Lz4JavaCompressor blockCompressor = new Lz4JavaCompressor();
+
+    @Override
+    public int maxCompressedLength(int uncompressedSize)
+    {
+        return Lz4FrameCompression.maxCompressedLength(uncompressedSize);
+    }
+
+    @Override
+    public int compress(byte[] input, int inputOffset, int inputLength, byte[] output, int outputOffset, int maxOutputLength)
+    {
+        return Lz4FrameCompression.compress(blockCompressor, input, inputOffset, inputLength, output, outputOffset, maxOutputLength);
+    }
+
+    @Override
+    public int compress(MemorySegment input, MemorySegment output)
+    {
+        return Lz4FrameCompression.compress(blockCompressor, input, output);
+    }
+}

--- a/src/main/java/io/airlift/compress/v3/lz4/Lz4FrameJavaDecompressor.java
+++ b/src/main/java/io/airlift/compress/v3/lz4/Lz4FrameJavaDecompressor.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.compress.v3.lz4;
+
+import io.airlift.compress.v3.MalformedInputException;
+
+import java.lang.foreign.MemorySegment;
+
+/**
+ * Pure-Java decompressor for the standard LZ4 frame format, delegating per-block decompression to
+ * the Java LZ4 block decompressor. Multiple concatenated frames are decoded, and skippable frames
+ * are ignored. Only frames with independent blocks and no dictionary are supported (as produced by
+ * the Java and native frame compressors); frames using linked blocks or a dictionary are rejected.
+ * This class is not thread-safe.
+ */
+public final class Lz4FrameJavaDecompressor
+        implements Lz4FrameDecompressor
+{
+    private final Lz4JavaDecompressor blockDecompressor = new Lz4JavaDecompressor();
+
+    @Override
+    public int decompress(byte[] input, int inputOffset, int inputLength, byte[] output, int outputOffset, int maxOutputLength)
+            throws MalformedInputException
+    {
+        return Lz4FrameCompression.decompress(blockDecompressor, input, inputOffset, inputLength, output, outputOffset, maxOutputLength);
+    }
+
+    @Override
+    public int decompress(MemorySegment input, MemorySegment output)
+            throws MalformedInputException
+    {
+        return Lz4FrameCompression.decompress(blockDecompressor, input, output);
+    }
+}

--- a/src/main/java/io/airlift/compress/v3/lz4/Lz4FrameNativeCompressor.java
+++ b/src/main/java/io/airlift/compress/v3/lz4/Lz4FrameNativeCompressor.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.compress.v3.lz4;
+
+import java.lang.foreign.MemorySegment;
+
+/**
+ * Compressor that produces the standard LZ4 frame format, delegating per-block compression to the
+ * native LZ4 block compressor. The frame container itself (including the xxHash32 header checksum)
+ * is written in Java, so only the raw block functions of the native library are used. Frames are
+ * emitted with independent blocks.
+ * <p>
+ * A single compressor is not safe to use by multiple threads concurrently. However, different
+ * threads may use different compressors concurrently.
+ */
+public final class Lz4FrameNativeCompressor
+        implements Lz4FrameCompressor
+{
+    private final Lz4NativeCompressor blockCompressor;
+
+    public Lz4FrameNativeCompressor()
+    {
+        this.blockCompressor = new Lz4NativeCompressor();
+    }
+
+    public Lz4FrameNativeCompressor(int acceleration)
+    {
+        this.blockCompressor = new Lz4NativeCompressor(acceleration);
+    }
+
+    public static boolean isEnabled()
+    {
+        return Lz4NativeCompressor.isEnabled();
+    }
+
+    @Override
+    public int maxCompressedLength(int uncompressedSize)
+    {
+        return Lz4FrameCompression.maxCompressedLength(uncompressedSize);
+    }
+
+    @Override
+    public int compress(byte[] input, int inputOffset, int inputLength, byte[] output, int outputOffset, int maxOutputLength)
+    {
+        return Lz4FrameCompression.compress(blockCompressor, input, inputOffset, inputLength, output, outputOffset, maxOutputLength);
+    }
+
+    @Override
+    public int compress(MemorySegment input, MemorySegment output)
+    {
+        return Lz4FrameCompression.compress(blockCompressor, input, output);
+    }
+}

--- a/src/main/java/io/airlift/compress/v3/lz4/Lz4FrameNativeDecompressor.java
+++ b/src/main/java/io/airlift/compress/v3/lz4/Lz4FrameNativeDecompressor.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.compress.v3.lz4;
+
+import io.airlift.compress.v3.MalformedInputException;
+
+import java.lang.foreign.MemorySegment;
+
+/**
+ * Decompressor for the standard LZ4 frame format, delegating per-block decompression to the native
+ * LZ4 block decompressor. The frame container is parsed in Java, so only the raw block functions of
+ * the native library are used. Multiple concatenated frames are decoded, and skippable frames are
+ * ignored. Only frames with independent blocks and no dictionary are supported (as produced by the
+ * Java and native frame compressors); frames using linked blocks or a dictionary are rejected.
+ * <p>
+ * A single decompressor is not safe to use by multiple threads concurrently. However, different
+ * threads may use different decompressors concurrently.
+ */
+public final class Lz4FrameNativeDecompressor
+        implements Lz4FrameDecompressor
+{
+    private final Lz4NativeDecompressor blockDecompressor;
+
+    public Lz4FrameNativeDecompressor()
+    {
+        this.blockDecompressor = new Lz4NativeDecompressor();
+    }
+
+    public static boolean isEnabled()
+    {
+        return Lz4NativeDecompressor.isEnabled();
+    }
+
+    @Override
+    public int decompress(byte[] input, int inputOffset, int inputLength, byte[] output, int outputOffset, int maxOutputLength)
+            throws MalformedInputException
+    {
+        return Lz4FrameCompression.decompress(blockDecompressor, input, inputOffset, inputLength, output, outputOffset, maxOutputLength);
+    }
+
+    @Override
+    public int decompress(MemorySegment input, MemorySegment output)
+            throws MalformedInputException
+    {
+        return Lz4FrameCompression.decompress(blockDecompressor, input, output);
+    }
+}

--- a/src/main/java/io/airlift/compress/v3/xxhash/XxHash32Bindings.java
+++ b/src/main/java/io/airlift/compress/v3/xxhash/XxHash32Bindings.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.compress.v3.xxhash;
+
+import io.airlift.compress.v3.internal.NativeLoader;
+import io.airlift.compress.v3.internal.NativeLoader.Symbols;
+import io.airlift.compress.v3.internal.NativeSignature;
+
+import java.lang.foreign.MemorySegment;
+import java.lang.invoke.MethodHandle;
+import java.util.Optional;
+
+import static java.lang.invoke.MethodHandles.lookup;
+
+final class XxHash32Bindings
+{
+    private XxHash32Bindings() {}
+
+    private record MethodHandles(
+            // One-shot hash
+            @NativeSignature(name = "XXH32", returnType = int.class, argumentTypes = {MemorySegment.class, long.class, int.class})
+            MethodHandle hash,
+            // State management
+            @NativeSignature(name = "XXH32_createState", returnType = MemorySegment.class, argumentTypes = {})
+            MethodHandle createState,
+            @NativeSignature(name = "XXH32_freeState", returnType = int.class, argumentTypes = MemorySegment.class)
+            MethodHandle freeState,
+            // Streaming
+            @NativeSignature(name = "XXH32_reset", returnType = int.class, argumentTypes = {MemorySegment.class, int.class})
+            MethodHandle reset,
+            @NativeSignature(name = "XXH32_update", returnType = int.class, argumentTypes = {MemorySegment.class, MemorySegment.class, long.class})
+            MethodHandle update,
+            @NativeSignature(name = "XXH32_digest", returnType = int.class, argumentTypes = MemorySegment.class)
+            MethodHandle digest) {}
+
+    private static final Optional<LinkageError> LINKAGE_ERROR;
+
+    private static final MethodHandle HASH_METHOD;
+    private static final MethodHandle CREATE_STATE_METHOD;
+    private static final MethodHandle FREE_STATE_METHOD;
+    private static final MethodHandle RESET_METHOD;
+    private static final MethodHandle UPDATE_METHOD;
+    private static final MethodHandle DIGEST_METHOD;
+
+    static {
+        Symbols<MethodHandles> symbols = NativeLoader.loadSymbols("xxhash", MethodHandles.class, lookup());
+        LINKAGE_ERROR = symbols.linkageError();
+        MethodHandles methodHandles = symbols.symbols();
+
+        HASH_METHOD = methodHandles.hash();
+        CREATE_STATE_METHOD = methodHandles.createState();
+        FREE_STATE_METHOD = methodHandles.freeState();
+        RESET_METHOD = methodHandles.reset();
+        UPDATE_METHOD = methodHandles.update();
+        DIGEST_METHOD = methodHandles.digest();
+    }
+
+    public static boolean isEnabled()
+    {
+        return LINKAGE_ERROR.isEmpty();
+    }
+
+    public static void verifyEnabled()
+    {
+        if (LINKAGE_ERROR.isPresent()) {
+            throw new IllegalStateException("XxHash32 native library is not enabled", LINKAGE_ERROR.get());
+        }
+    }
+
+    public static int hash(MemorySegment input, long length, int seed)
+    {
+        try {
+            return (int) HASH_METHOD.invokeExact(input, length, seed);
+        }
+        catch (Throwable e) {
+            throw new AssertionError("should not reach here", e);
+        }
+    }
+
+    public static MemorySegment createState()
+    {
+        try {
+            return (MemorySegment) CREATE_STATE_METHOD.invokeExact();
+        }
+        catch (Throwable e) {
+            throw new AssertionError("should not reach here", e);
+        }
+    }
+
+    public static void freeState(MemorySegment state)
+    {
+        try {
+            int result = (int) FREE_STATE_METHOD.invokeExact(state);
+            if (result != 0) {
+                throw new IllegalStateException("XXH32_freeState failed: " + result);
+            }
+        }
+        catch (Throwable e) {
+            throw new AssertionError("should not reach here", e);
+        }
+    }
+
+    public static void reset(MemorySegment state, int seed)
+    {
+        try {
+            int result = (int) RESET_METHOD.invokeExact(state, seed);
+            if (result != 0) {
+                throw new IllegalStateException("XXH32_reset failed: " + result);
+            }
+        }
+        catch (Throwable e) {
+            throw new AssertionError("should not reach here", e);
+        }
+    }
+
+    public static void update(MemorySegment state, MemorySegment input, long length)
+    {
+        try {
+            int result = (int) UPDATE_METHOD.invokeExact(state, input, length);
+            if (result != 0) {
+                throw new IllegalStateException("XXH32_update failed: " + result);
+            }
+        }
+        catch (Throwable e) {
+            throw new AssertionError("should not reach here", e);
+        }
+    }
+
+    public static int digest(MemorySegment state)
+    {
+        try {
+            return (int) DIGEST_METHOD.invokeExact(state);
+        }
+        catch (Throwable e) {
+            throw new AssertionError("should not reach here", e);
+        }
+    }
+}

--- a/src/main/java/io/airlift/compress/v3/xxhash/XxHash32Hasher.java
+++ b/src/main/java/io/airlift/compress/v3/xxhash/XxHash32Hasher.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.compress.v3.xxhash;
+
+import java.lang.foreign.MemorySegment;
+
+/**
+ * XXHash32 hash function with support for both one-shot and streaming hashing.
+ * <p>
+ * For one-shot hashing, use the static methods:
+ * <pre>
+ * int hash = XxHash32Hasher.hash(data);
+ * int hash = XxHash32Hasher.hash(data, seed);
+ * </pre>
+ * <p>
+ * For streaming (incremental) hashing, use the factory methods:
+ * <pre>
+ * try (XxHash32Hasher hasher = XxHash32Hasher.create()) {
+ *     hasher.update(chunk1);
+ *     hasher.update(chunk2);
+ *     int hash = hasher.digest();
+ * }
+ * </pre>
+ * <p>
+ * Streaming hasher instances are not thread-safe and must not be used concurrently
+ * from multiple threads without external synchronization.
+ */
+public sealed interface XxHash32Hasher
+        extends AutoCloseable
+        permits XxHash32JavaHasher, XxHash32NativeHasher
+{
+    int DEFAULT_SEED = 0;
+
+    // ========== Static one-shot methods ==========
+
+    static int hash(byte[] input)
+    {
+        return hash(input, 0, input.length, DEFAULT_SEED);
+    }
+
+    static int hash(byte[] input, int offset, int length)
+    {
+        return hash(input, offset, length, DEFAULT_SEED);
+    }
+
+    static int hash(byte[] input, int seed)
+    {
+        return hash(input, 0, input.length, seed);
+    }
+
+    static int hash(byte[] input, int offset, int length, int seed)
+    {
+        if (XxHash32NativeHasher.isEnabled()) {
+            return XxHash32NativeHasher.hash(input, offset, length, seed);
+        }
+        return XxHash32JavaHasher.hash(input, offset, length, seed);
+    }
+
+    static int hash(MemorySegment input)
+    {
+        return hash(input, DEFAULT_SEED);
+    }
+
+    static int hash(MemorySegment input, int seed)
+    {
+        if (XxHash32NativeHasher.isEnabled()) {
+            return XxHash32NativeHasher.hash(input, seed);
+        }
+        return XxHash32JavaHasher.hash(input, seed);
+    }
+
+    // ========== Factory methods for streaming ==========
+
+    static XxHash32Hasher create()
+    {
+        return create(DEFAULT_SEED);
+    }
+
+    static XxHash32Hasher create(int seed)
+    {
+        if (XxHash32NativeHasher.isEnabled()) {
+            return new XxHash32NativeHasher(seed);
+        }
+        return new XxHash32JavaHasher(seed);
+    }
+
+    // ========== Instance methods for streaming ==========
+
+    /**
+     * Updates the hash state with the given input data.
+     *
+     * @return this hasher for fluent chaining
+     */
+    XxHash32Hasher update(byte[] input);
+
+    /**
+     * Updates the hash state with the given input data.
+     *
+     * @return this hasher for fluent chaining
+     */
+    XxHash32Hasher update(byte[] input, int offset, int length);
+
+    /**
+     * Updates the hash state with the given input data.
+     *
+     * @return this hasher for fluent chaining
+     */
+    XxHash32Hasher update(MemorySegment input);
+
+    /**
+     * Updates the hash state with the given int value in little-endian byte order.
+     * This is useful for hashing length-prefixed data without manual byte conversion.
+     *
+     * @return this hasher for fluent chaining
+     */
+    XxHash32Hasher updateLE(int value);
+
+    /**
+     * Computes and returns the 32-bit hash of all data passed to update().
+     * The state is not modified, so you can continue to call update() and digest().
+     */
+    int digest();
+
+    /**
+     * Resets the hasher to its initial state with the default seed.
+     *
+     * @return this hasher for fluent chaining
+     */
+    XxHash32Hasher reset();
+
+    /**
+     * Resets the hasher with the given seed.
+     *
+     * @return this hasher for fluent chaining
+     */
+    XxHash32Hasher reset(int seed);
+
+    /**
+     * Closes this hasher and releases any resources.
+     */
+    @Override
+    void close();
+}

--- a/src/main/java/io/airlift/compress/v3/xxhash/XxHash32JavaHasher.java
+++ b/src/main/java/io/airlift/compress/v3/xxhash/XxHash32JavaHasher.java
@@ -1,0 +1,368 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.compress.v3.xxhash;
+
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.nio.ByteOrder;
+
+import static java.lang.Integer.rotateLeft;
+import static java.lang.Math.min;
+import static java.lang.Math.toIntExact;
+import static java.util.Objects.checkFromIndexSize;
+
+public final class XxHash32JavaHasher
+        implements XxHash32Hasher
+{
+    private static final int PRIME32_1 = 0x9E3779B1;
+    private static final int PRIME32_2 = 0x85EBCA77;
+    private static final int PRIME32_3 = 0xC2B2AE3D;
+    private static final int PRIME32_4 = 0x27D4EB2F;
+    private static final int PRIME32_5 = 0x165667B1;
+
+    private static final int BLOCK_SIZE = 16;
+
+    private static final VarHandle INT_HANDLE = MethodHandles.byteArrayViewVarHandle(int[].class, ByteOrder.LITTLE_ENDIAN);
+
+    private final byte[] buffer = new byte[BLOCK_SIZE];
+    private int bufferSize;
+
+    private long bodyLength;
+
+    private int v1;
+    private int v2;
+    private int v3;
+    private int v4;
+
+    private int seed;
+
+    public XxHash32JavaHasher(int seed)
+    {
+        this.seed = seed;
+        resetState(seed);
+    }
+
+    private void resetState(int seed)
+    {
+        this.v1 = seed + PRIME32_1 + PRIME32_2;
+        this.v2 = seed + PRIME32_2;
+        this.v3 = seed;
+        this.v4 = seed - PRIME32_1;
+        this.bufferSize = 0;
+        this.bodyLength = 0;
+    }
+
+    public static int hash(byte[] input, int offset, int length, int seed)
+    {
+        checkFromIndexSize(offset, length, input.length);
+
+        int hash;
+        int index = offset;
+        int end = offset + length;
+
+        if (length >= BLOCK_SIZE) {
+            int v1 = seed + PRIME32_1 + PRIME32_2;
+            int v2 = seed + PRIME32_2;
+            int v3 = seed;
+            int v4 = seed - PRIME32_1;
+
+            while (index <= end - BLOCK_SIZE) {
+                v1 = mix(v1, (int) INT_HANDLE.get(input, index));
+                v2 = mix(v2, (int) INT_HANDLE.get(input, index + 4));
+                v3 = mix(v3, (int) INT_HANDLE.get(input, index + 8));
+                v4 = mix(v4, (int) INT_HANDLE.get(input, index + 12));
+                index += BLOCK_SIZE;
+            }
+
+            hash = rotateLeft(v1, 1) + rotateLeft(v2, 7) + rotateLeft(v3, 12) + rotateLeft(v4, 18);
+        }
+        else {
+            hash = seed + PRIME32_5;
+        }
+
+        hash += length;
+
+        // Process remaining bytes
+        while (index <= end - 4) {
+            hash = updateTail(hash, (int) INT_HANDLE.get(input, index));
+            index += 4;
+        }
+
+        while (index < end) {
+            hash = updateTail(hash, input[index]);
+            index++;
+        }
+
+        return finalShuffle(hash);
+    }
+
+    public static int hash(MemorySegment input, int seed)
+    {
+        // For heap segments backed by byte arrays, extract and use direct array access
+        if (input.isNative()) {
+            return hashSegment(input, seed);
+        }
+
+        byte[] array = input.heapBase()
+                .filter(base -> base instanceof byte[])
+                .map(base -> (byte[]) base)
+                .orElse(null);
+
+        if (array != null) {
+            // heapBase gives us the array, address gives us the offset from the array start
+            return hash(array, toIntExact(input.address()), toIntExact(input.byteSize()), seed);
+        }
+
+        return hashSegment(input, seed);
+    }
+
+    private static int hashSegment(MemorySegment input, int seed)
+    {
+        long length = input.byteSize();
+        int hash;
+        long index = 0;
+
+        if (length >= BLOCK_SIZE) {
+            int v1 = seed + PRIME32_1 + PRIME32_2;
+            int v2 = seed + PRIME32_2;
+            int v3 = seed;
+            int v4 = seed - PRIME32_1;
+
+            while (index <= length - BLOCK_SIZE) {
+                v1 = mix(v1, input.get(ValueLayout.JAVA_INT_UNALIGNED, index));
+                v2 = mix(v2, input.get(ValueLayout.JAVA_INT_UNALIGNED, index + 4));
+                v3 = mix(v3, input.get(ValueLayout.JAVA_INT_UNALIGNED, index + 8));
+                v4 = mix(v4, input.get(ValueLayout.JAVA_INT_UNALIGNED, index + 12));
+                index += BLOCK_SIZE;
+            }
+
+            hash = rotateLeft(v1, 1) + rotateLeft(v2, 7) + rotateLeft(v3, 12) + rotateLeft(v4, 18);
+        }
+        else {
+            hash = seed + PRIME32_5;
+        }
+
+        hash += (int) length;
+
+        while (index <= length - 4) {
+            hash = updateTail(hash, input.get(ValueLayout.JAVA_INT_UNALIGNED, index));
+            index += 4;
+        }
+
+        while (index < length) {
+            hash = updateTail(hash, input.get(ValueLayout.JAVA_BYTE, index));
+            index++;
+        }
+
+        return finalShuffle(hash);
+    }
+
+    @Override
+    public XxHash32Hasher update(byte[] input)
+    {
+        return update(input, 0, input.length);
+    }
+
+    @Override
+    public XxHash32Hasher update(byte[] input, int offset, int length)
+    {
+        checkFromIndexSize(offset, length, input.length);
+
+        int index = offset;
+        int remaining = length;
+
+        // Fill buffer if partially filled
+        if (bufferSize > 0) {
+            int available = min(BLOCK_SIZE - bufferSize, remaining);
+            System.arraycopy(input, index, buffer, bufferSize, available);
+
+            bufferSize += available;
+            index += available;
+            remaining -= available;
+
+            if (bufferSize == BLOCK_SIZE) {
+                updateBodyFromBuffer();
+                bufferSize = 0;
+            }
+        }
+
+        // Process full 16-byte blocks directly from input
+        while (remaining >= BLOCK_SIZE) {
+            v1 = mix(v1, (int) INT_HANDLE.get(input, index));
+            v2 = mix(v2, (int) INT_HANDLE.get(input, index + 4));
+            v3 = mix(v3, (int) INT_HANDLE.get(input, index + 8));
+            v4 = mix(v4, (int) INT_HANDLE.get(input, index + 12));
+
+            index += BLOCK_SIZE;
+            remaining -= BLOCK_SIZE;
+            bodyLength += BLOCK_SIZE;
+        }
+
+        // Buffer remaining bytes
+        if (remaining > 0) {
+            System.arraycopy(input, index, buffer, bufferSize, remaining);
+            bufferSize += remaining;
+        }
+
+        return this;
+    }
+
+    @Override
+    public XxHash32Hasher update(MemorySegment input)
+    {
+        byte[] array = input.heapBase()
+                .filter(base -> base instanceof byte[])
+                .map(base -> (byte[]) base)
+                .orElse(null);
+
+        if (array != null) {
+            return update(array, toIntExact(input.address()), toIntExact(input.byteSize()));
+        }
+
+        // Fall back to MemorySegment access for native memory
+        return updateSegment(input);
+    }
+
+    private XxHash32Hasher updateSegment(MemorySegment input)
+    {
+        long length = input.byteSize();
+        long inputOffset = 0;
+
+        if (bufferSize > 0) {
+            int available = (int) min(BLOCK_SIZE - bufferSize, length);
+            for (int i = 0; i < available; i++) {
+                buffer[bufferSize + i] = input.get(ValueLayout.JAVA_BYTE, inputOffset + i);
+            }
+
+            bufferSize += available;
+            inputOffset += available;
+            length -= available;
+
+            if (bufferSize == BLOCK_SIZE) {
+                updateBodyFromBuffer();
+                bufferSize = 0;
+            }
+        }
+
+        while (length >= BLOCK_SIZE) {
+            v1 = mix(v1, input.get(ValueLayout.JAVA_INT_UNALIGNED, inputOffset));
+            v2 = mix(v2, input.get(ValueLayout.JAVA_INT_UNALIGNED, inputOffset + 4));
+            v3 = mix(v3, input.get(ValueLayout.JAVA_INT_UNALIGNED, inputOffset + 8));
+            v4 = mix(v4, input.get(ValueLayout.JAVA_INT_UNALIGNED, inputOffset + 12));
+
+            inputOffset += BLOCK_SIZE;
+            length -= BLOCK_SIZE;
+            bodyLength += BLOCK_SIZE;
+        }
+
+        if (length > 0) {
+            for (int i = 0; i < length; i++) {
+                buffer[bufferSize + i] = input.get(ValueLayout.JAVA_BYTE, inputOffset + i);
+            }
+            bufferSize += (int) length;
+        }
+
+        return this;
+    }
+
+    @Override
+    public XxHash32Hasher updateLE(int value)
+    {
+        byte[] bytes = new byte[4];
+        INT_HANDLE.set(bytes, 0, value);
+        return update(bytes);
+    }
+
+    private void updateBodyFromBuffer()
+    {
+        v1 = mix(v1, (int) INT_HANDLE.get(buffer, 0));
+        v2 = mix(v2, (int) INT_HANDLE.get(buffer, 4));
+        v3 = mix(v3, (int) INT_HANDLE.get(buffer, 8));
+        v4 = mix(v4, (int) INT_HANDLE.get(buffer, 12));
+        bodyLength += BLOCK_SIZE;
+    }
+
+    @Override
+    public int digest()
+    {
+        int hash;
+        if (bodyLength > 0) {
+            hash = rotateLeft(v1, 1) + rotateLeft(v2, 7) + rotateLeft(v3, 12) + rotateLeft(v4, 18);
+        }
+        else {
+            hash = seed + PRIME32_5;
+        }
+
+        hash += (int) (bodyLength + bufferSize);
+
+        // Process remaining bytes in buffer
+        int index = 0;
+        while (index <= bufferSize - 4) {
+            hash = updateTail(hash, (int) INT_HANDLE.get(buffer, index));
+            index += 4;
+        }
+
+        while (index < bufferSize) {
+            hash = updateTail(hash, buffer[index]);
+            index++;
+        }
+
+        return finalShuffle(hash);
+    }
+
+    @Override
+    public XxHash32Hasher reset()
+    {
+        return reset(DEFAULT_SEED);
+    }
+
+    @Override
+    public XxHash32Hasher reset(int seed)
+    {
+        this.seed = seed;
+        resetState(seed);
+        return this;
+    }
+
+    @Override
+    public void close() {}
+
+    private static int mix(int current, int value)
+    {
+        return rotateLeft(current + value * PRIME32_2, 13) * PRIME32_1;
+    }
+
+    private static int updateTail(int hash, int value)
+    {
+        return rotateLeft(hash + value * PRIME32_3, 17) * PRIME32_4;
+    }
+
+    private static int updateTail(int hash, byte value)
+    {
+        int unsigned = value & 0xFF;
+        return rotateLeft(hash + unsigned * PRIME32_5, 11) * PRIME32_1;
+    }
+
+    private static int finalShuffle(int hash)
+    {
+        hash ^= hash >>> 15;
+        hash *= PRIME32_2;
+        hash ^= hash >>> 13;
+        hash *= PRIME32_3;
+        hash ^= hash >>> 16;
+        return hash;
+    }
+}

--- a/src/main/java/io/airlift/compress/v3/xxhash/XxHash32NativeHasher.java
+++ b/src/main/java/io/airlift/compress/v3/xxhash/XxHash32NativeHasher.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.compress.v3.xxhash;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.lang.ref.Cleaner;
+import java.nio.ByteOrder;
+
+import static java.util.Objects.checkFromIndexSize;
+
+public final class XxHash32NativeHasher
+        implements XxHash32Hasher
+{
+    private static final Cleaner CLEANER = Cleaner.create();
+    private static final ValueLayout.OfInt JAVA_INT_LE_UNALIGNED = ValueLayout.JAVA_INT_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN);
+
+    private final MemorySegment state;
+    private final Cleaner.Cleanable cleanable;
+    private final byte[] scratch = new byte[4];
+    private boolean closed;
+
+    public XxHash32NativeHasher(int seed)
+    {
+        XxHash32Bindings.verifyEnabled();
+
+        NativeResources resources = new NativeResources();
+        this.cleanable = CLEANER.register(this, resources);
+        Arena arena = resources.arena();
+
+        MemorySegment rawState = XxHash32Bindings.createState();
+        if (rawState.equals(MemorySegment.NULL)) {
+            cleanable.clean();
+            throw new IllegalStateException("Failed to create XXH32 state");
+        }
+        this.state = rawState.reinterpret(arena, XxHash32Bindings::freeState);
+        XxHash32Bindings.reset(state, seed);
+    }
+
+    // ========== Static methods ==========
+
+    public static boolean isEnabled()
+    {
+        return XxHash32Bindings.isEnabled();
+    }
+
+    public static int hash(byte[] input, int offset, int length, int seed)
+    {
+        checkFromIndexSize(offset, length, input.length);
+        XxHash32Bindings.verifyEnabled();
+        MemorySegment segment = MemorySegment.ofArray(input).asSlice(offset, length);
+        return XxHash32Bindings.hash(segment, length, seed);
+    }
+
+    public static int hash(MemorySegment input, int seed)
+    {
+        XxHash32Bindings.verifyEnabled();
+        return XxHash32Bindings.hash(input, input.byteSize(), seed);
+    }
+
+    // ========== Instance streaming methods ==========
+
+    @Override
+    public XxHash32Hasher update(byte[] input)
+    {
+        return update(input, 0, input.length);
+    }
+
+    @Override
+    public XxHash32Hasher update(byte[] input, int offset, int length)
+    {
+        checkFromIndexSize(offset, length, input.length);
+        checkNotClosed();
+        MemorySegment segment = MemorySegment.ofArray(input).asSlice(offset, length);
+        XxHash32Bindings.update(state, segment, length);
+        return this;
+    }
+
+    @Override
+    public XxHash32Hasher update(MemorySegment input)
+    {
+        checkNotClosed();
+        XxHash32Bindings.update(state, input, input.byteSize());
+        return this;
+    }
+
+    @Override
+    public XxHash32Hasher updateLE(int value)
+    {
+        checkNotClosed();
+        MemorySegment segment = MemorySegment.ofArray(scratch);
+        segment.set(JAVA_INT_LE_UNALIGNED, 0, value);
+        XxHash32Bindings.update(state, segment, 4);
+        return this;
+    }
+
+    @Override
+    public int digest()
+    {
+        checkNotClosed();
+        return XxHash32Bindings.digest(state);
+    }
+
+    @Override
+    public XxHash32Hasher reset()
+    {
+        return reset(DEFAULT_SEED);
+    }
+
+    @Override
+    public XxHash32Hasher reset(int seed)
+    {
+        checkNotClosed();
+        XxHash32Bindings.reset(state, seed);
+        return this;
+    }
+
+    private void checkNotClosed()
+    {
+        if (closed) {
+            throw new IllegalStateException("Hasher has been closed");
+        }
+    }
+
+    @Override
+    public void close()
+    {
+        if (!closed) {
+            closed = true;
+            cleanable.clean();
+        }
+    }
+
+    /**
+     * Holds native resources that must be freed.
+     * Implements Runnable so it can be used with Cleaner.
+     */
+    private record NativeResources(Arena arena)
+            implements Runnable
+    {
+        NativeResources()
+        {
+            this(Arena.ofShared());
+        }
+
+        @Override
+        public void run()
+        {
+            arena.close();
+        }
+    }
+}

--- a/src/test/java/io/airlift/compress/v3/benchmark/Algorithm.java
+++ b/src/test/java/io/airlift/compress/v3/benchmark/Algorithm.java
@@ -22,6 +22,10 @@ import io.airlift.compress.v3.deflate.DeflateJavaDecompressor;
 import io.airlift.compress.v3.deflate.DeflateNativeCompressor;
 import io.airlift.compress.v3.deflate.DeflateNativeDecompressor;
 import io.airlift.compress.v3.lz4.Lz4Codec;
+import io.airlift.compress.v3.lz4.Lz4FrameJavaCompressor;
+import io.airlift.compress.v3.lz4.Lz4FrameJavaDecompressor;
+import io.airlift.compress.v3.lz4.Lz4FrameNativeCompressor;
+import io.airlift.compress.v3.lz4.Lz4FrameNativeDecompressor;
 import io.airlift.compress.v3.lz4.Lz4JavaCompressor;
 import io.airlift.compress.v3.lz4.Lz4JavaDecompressor;
 import io.airlift.compress.v3.lz4.Lz4NativeCompressor;
@@ -57,6 +61,8 @@ public enum Algorithm
 {
     airlift_lz4(new Lz4JavaDecompressor(), new Lz4JavaCompressor()),
     airlift_lz4_native(new Lz4NativeDecompressor(), new Lz4NativeCompressor()),
+    airlift_lz4_frame(new Lz4FrameJavaDecompressor(), new Lz4FrameJavaCompressor()),
+    airlift_lz4_frame_native(new Lz4FrameNativeDecompressor(), new Lz4FrameNativeCompressor()),
     airlift_snappy(new SnappyJavaDecompressor(), new SnappyJavaCompressor()),
     airlift_snappy_native(new SnappyNativeDecompressor(), new SnappyNativeCompressor()),
     airlift_lzo(new LzoDecompressor(), new LzoCompressor()),

--- a/src/test/java/io/airlift/compress/v3/lz4/TestLz4FrameDecompressor.java
+++ b/src/test/java/io/airlift/compress/v3/lz4/TestLz4FrameDecompressor.java
@@ -1,0 +1,348 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.compress.v3.lz4;
+
+import com.google.common.primitives.Bytes;
+import io.airlift.compress.v3.MalformedInputException;
+import io.airlift.compress.v3.xxhash.XxHash32Hasher;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Arrays;
+
+import static io.airlift.compress.v3.lz4.Lz4FrameFormat.FLG_BLOCK_CHECKSUM;
+import static io.airlift.compress.v3.lz4.Lz4FrameFormat.FLG_BLOCK_INDEPENDENCE;
+import static io.airlift.compress.v3.lz4.Lz4FrameFormat.FLG_CONTENT_CHECKSUM;
+import static io.airlift.compress.v3.lz4.Lz4FrameFormat.FLG_CONTENT_SIZE;
+import static io.airlift.compress.v3.lz4.Lz4FrameFormat.FLG_DICTIONARY_ID;
+import static io.airlift.compress.v3.lz4.Lz4FrameFormat.FLG_RESERVED_MASK;
+import static io.airlift.compress.v3.lz4.Lz4FrameFormat.FLG_VERSION;
+import static io.airlift.compress.v3.lz4.Lz4FrameFormat.MAGIC;
+import static io.airlift.compress.v3.lz4.Lz4FrameFormat.SKIPPABLE_MAGIC;
+import static io.airlift.compress.v3.lz4.Lz4FrameFormat.UNCOMPRESSED_BLOCK_FLAG;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests the frame parsing and integrity validation of the LZ4 frame decompressor against
+ * hand-crafted frames that exercise features (concatenated and skippable frames, linked blocks,
+ * dictionaries, content size, block and content checksums) that the frame compressors do not emit
+ * themselves.
+ */
+class TestLz4FrameDecompressor
+{
+    private static final byte[] CONTENT = "the quick brown fox jumps over the lazy dog".getBytes(UTF_8);
+
+    private static byte[] decompress(byte[] frame, int outputSize)
+    {
+        byte[] output = new byte[outputSize];
+        int size = new Lz4FrameJavaDecompressor().decompress(frame, 0, frame.length, output, 0, output.length);
+        return Arrays.copyOf(output, size);
+    }
+
+    private static byte[] decompress(byte[] frame)
+    {
+        return decompress(frame, CONTENT.length);
+    }
+
+    @Test
+    void testValidContentChecksum()
+    {
+        byte[] frame = frame(FLG_BLOCK_INDEPENDENCE | FLG_CONTENT_CHECKSUM).build();
+        assertThat(decompress(frame)).isEqualTo(CONTENT);
+    }
+
+    @Test
+    void testInvalidContentChecksumIsRejected()
+    {
+        byte[] frame = frame(FLG_BLOCK_INDEPENDENCE | FLG_CONTENT_CHECKSUM).contentChecksum(xxHash32(CONTENT) ^ 0x1).build();
+        assertThatThrownBy(() -> decompress(frame))
+                .isInstanceOf(MalformedInputException.class)
+                .hasMessageContaining("invalid content checksum");
+    }
+
+    @Test
+    void testValidBlockChecksum()
+    {
+        byte[] frame = frame(FLG_BLOCK_INDEPENDENCE | FLG_BLOCK_CHECKSUM).build();
+        assertThat(decompress(frame)).isEqualTo(CONTENT);
+    }
+
+    @Test
+    void testInvalidBlockChecksumIsRejected()
+    {
+        byte[] frame = frame(FLG_BLOCK_INDEPENDENCE | FLG_BLOCK_CHECKSUM).blockChecksum(xxHash32(CONTENT) ^ 0x1).build();
+        assertThatThrownBy(() -> decompress(frame))
+                .isInstanceOf(MalformedInputException.class)
+                .hasMessageContaining("invalid block checksum");
+    }
+
+    @Test
+    void testValidContentSize()
+    {
+        byte[] frame = frame(FLG_BLOCK_INDEPENDENCE | FLG_CONTENT_SIZE).contentSize(CONTENT.length).build();
+        assertThat(decompress(frame)).isEqualTo(CONTENT);
+    }
+
+    @Test
+    void testMismatchedContentSizeIsRejected()
+    {
+        byte[] frame = frame(FLG_BLOCK_INDEPENDENCE | FLG_CONTENT_SIZE).contentSize(CONTENT.length + 1).build();
+        assertThatThrownBy(() -> decompress(frame))
+                .isInstanceOf(MalformedInputException.class)
+                .hasMessageContaining("content size does not match");
+    }
+
+    @Test
+    void testLinkedBlocksAreRejected()
+    {
+        // block independence flag not set
+        byte[] frame = frame(0).build();
+        assertThatThrownBy(() -> decompress(frame))
+                .isInstanceOf(MalformedInputException.class)
+                .hasMessageContaining("linked blocks are not supported");
+    }
+
+    @Test
+    void testDictionaryIsRejected()
+    {
+        byte[] frame = frame(FLG_BLOCK_INDEPENDENCE | FLG_DICTIONARY_ID).build();
+        assertThatThrownBy(() -> decompress(frame))
+                .isInstanceOf(MalformedInputException.class)
+                .hasMessageContaining("dictionary are not supported");
+    }
+
+    @Test
+    void testReservedFlgBitIsRejected()
+    {
+        byte[] frame = frame(FLG_BLOCK_INDEPENDENCE | FLG_RESERVED_MASK).build();
+        assertThatThrownBy(() -> decompress(frame))
+                .isInstanceOf(MalformedInputException.class)
+                .hasMessageContaining("reserved bits");
+    }
+
+    @Test
+    void testReservedBdBitIsRejected()
+    {
+        byte[] frame = frame(FLG_BLOCK_INDEPENDENCE).blockDescriptor(0x71).build();
+        assertThatThrownBy(() -> decompress(frame))
+                .isInstanceOf(MalformedInputException.class)
+                .hasMessageContaining("reserved bits");
+    }
+
+    @Test
+    void testInvalidMagicIsRejected()
+    {
+        byte[] frame = frame(FLG_BLOCK_INDEPENDENCE).build();
+        frame[0] ^= 0xFF;
+        assertThatThrownBy(() -> decompress(frame))
+                .isInstanceOf(MalformedInputException.class)
+                .hasMessageContaining("magic number");
+    }
+
+    @Test
+    void testUnsupportedVersionIsRejected()
+    {
+        byte[] frame = frame(FLG_BLOCK_INDEPENDENCE).build();
+        // clear the version bits (bits 7-6) of the FLG byte, which follows the 4 byte magic
+        frame[4] &= 0x3F;
+        assertThatThrownBy(() -> decompress(frame))
+                .isInstanceOf(MalformedInputException.class)
+                .hasMessageContaining("Unsupported LZ4 frame version");
+    }
+
+    @Test
+    void testInvalidBlockMaximumSizeIsRejected()
+    {
+        // block maximum size ids 0-3 are invalid; only 4-7 are defined
+        byte[] frame = frame(FLG_BLOCK_INDEPENDENCE).blockDescriptor(0x10).build();
+        assertThatThrownBy(() -> decompress(frame))
+                .isInstanceOf(MalformedInputException.class)
+                .hasMessageContaining("block maximum size");
+    }
+
+    @Test
+    void testInvalidHeaderChecksumIsRejected()
+    {
+        byte[] frame = frame(FLG_BLOCK_INDEPENDENCE).build();
+        // the header checksum byte follows the 4 byte magic and the 2 byte descriptor
+        frame[6] ^= 0xFF;
+        assertThatThrownBy(() -> decompress(frame))
+                .isInstanceOf(MalformedInputException.class)
+                .hasMessageContaining("invalid header checksum");
+    }
+
+    @Test
+    void testConcatenatedFramesAreAllDecoded()
+    {
+        byte[] frame = frame(FLG_BLOCK_INDEPENDENCE | FLG_CONTENT_CHECKSUM).build();
+        byte[] concatenated = Bytes.concat(frame, frame, frame);
+
+        assertThat(decompress(concatenated, CONTENT.length * 3))
+                .isEqualTo(Bytes.concat(CONTENT, CONTENT, CONTENT));
+    }
+
+    @Test
+    void testSkippableFramesAreIgnored()
+    {
+        byte[] frame = frame(FLG_BLOCK_INDEPENDENCE).build();
+        byte[] skippable = skippableFrame("ignored metadata".getBytes(UTF_8));
+
+        // before, between and after the content frames
+        byte[] concatenated = Bytes.concat(skippable, frame, skippable, frame, skippable);
+
+        assertThat(decompress(concatenated, CONTENT.length * 2))
+                .isEqualTo(Bytes.concat(CONTENT, CONTENT));
+    }
+
+    @Test
+    void testEmptySkippableFrameIsIgnored()
+    {
+        byte[] concatenated = Bytes.concat(skippableFrame(new byte[0]), frame(FLG_BLOCK_INDEPENDENCE).build());
+        assertThat(decompress(concatenated)).isEqualTo(CONTENT);
+    }
+
+    @Test
+    void testTruncatedSkippableFrameIsRejected()
+    {
+        byte[] skippable = skippableFrame("ignored metadata".getBytes(UTF_8));
+        byte[] truncated = Arrays.copyOf(skippable, skippable.length - 1);
+        byte[] concatenated = Bytes.concat(frame(FLG_BLOCK_INDEPENDENCE).build(), truncated);
+
+        assertThatThrownBy(() -> decompress(concatenated))
+                .isInstanceOf(MalformedInputException.class)
+                .hasMessageContaining("Truncated LZ4 skippable frame");
+    }
+
+    @Test
+    void testTrailingGarbageIsRejected()
+    {
+        byte[] concatenated = Bytes.concat(frame(FLG_BLOCK_INDEPENDENCE).build(), new byte[] {1, 2, 3, 4, 5});
+        assertThatThrownBy(() -> decompress(concatenated))
+                .isInstanceOf(MalformedInputException.class)
+                .hasMessageContaining("magic number");
+    }
+
+    private static byte[] skippableFrame(byte[] content)
+    {
+        ByteArrayOutputStream frame = new ByteArrayOutputStream();
+        writeInt(frame, SKIPPABLE_MAGIC);
+        writeInt(frame, content.length);
+        frame.write(content, 0, content.length);
+        return frame.toByteArray();
+    }
+
+    private static FrameBuilder frame(int flags)
+    {
+        return new FrameBuilder(flags);
+    }
+
+    private static int xxHash32(byte[] data)
+    {
+        return XxHash32Hasher.hash(data);
+    }
+
+    private static void writeInt(ByteArrayOutputStream out, int value)
+    {
+        for (int i = 0; i < Integer.BYTES; i++) {
+            out.write((value >>> (8 * i)) & 0xFF);
+        }
+    }
+
+    private static void writeLong(ByteArrayOutputStream out, long value)
+    {
+        for (int i = 0; i < Long.BYTES; i++) {
+            out.write((int) ((value >>> (8 * i)) & 0xFF));
+        }
+    }
+
+    /**
+     * Builds a single-block LZ4 frame holding {@link #CONTENT} as an uncompressed block, with a
+     * valid header checksum and, by default, valid optional fields for whichever flags are set.
+     * Individual fields can be overridden to exercise rejection paths.
+     */
+    private static final class FrameBuilder
+    {
+        private final int flg;
+        private int bd = 0x70; // 4 MB block maximum size
+        private long contentSize = CONTENT.length;
+        private Integer blockChecksum;
+        private Integer contentChecksum;
+
+        private FrameBuilder(int flags)
+        {
+            this.flg = FLG_VERSION | flags;
+        }
+
+        FrameBuilder blockDescriptor(int bd)
+        {
+            this.bd = bd;
+            return this;
+        }
+
+        FrameBuilder contentSize(long contentSize)
+        {
+            this.contentSize = contentSize;
+            return this;
+        }
+
+        FrameBuilder blockChecksum(int blockChecksum)
+        {
+            this.blockChecksum = blockChecksum;
+            return this;
+        }
+
+        FrameBuilder contentChecksum(int contentChecksum)
+        {
+            this.contentChecksum = contentChecksum;
+            return this;
+        }
+
+        byte[] build()
+        {
+            // frame descriptor bytes (FLG, BD, optional content size and dictionary id),
+            // over which the header checksum is computed
+            ByteArrayOutputStream descriptor = new ByteArrayOutputStream();
+            descriptor.write(flg);
+            descriptor.write(bd);
+            if ((flg & FLG_CONTENT_SIZE) != 0) {
+                writeLong(descriptor, contentSize);
+            }
+            if ((flg & FLG_DICTIONARY_ID) != 0) {
+                writeInt(descriptor, 0xCAFEBABE);
+            }
+            byte[] descriptorBytes = descriptor.toByteArray();
+            int headerChecksum = (xxHash32(descriptorBytes) >>> 8) & 0xFF;
+
+            ByteArrayOutputStream frame = new ByteArrayOutputStream();
+            writeInt(frame, MAGIC);
+            frame.write(descriptorBytes, 0, descriptorBytes.length);
+            frame.write(headerChecksum);
+
+            // single uncompressed block
+            writeInt(frame, CONTENT.length | UNCOMPRESSED_BLOCK_FLAG);
+            frame.write(CONTENT, 0, CONTENT.length);
+            if ((flg & FLG_BLOCK_CHECKSUM) != 0) {
+                writeInt(frame, blockChecksum != null ? blockChecksum : xxHash32(CONTENT));
+            }
+
+            writeInt(frame, 0); // end mark
+            if ((flg & FLG_CONTENT_CHECKSUM) != 0) {
+                writeInt(frame, contentChecksum != null ? contentChecksum : xxHash32(CONTENT));
+            }
+            return frame.toByteArray();
+        }
+    }
+}

--- a/src/test/java/io/airlift/compress/v3/lz4/TestLz4FrameJava.java
+++ b/src/test/java/io/airlift/compress/v3/lz4/TestLz4FrameJava.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.compress.v3.lz4;
+
+import io.airlift.compress.v3.AbstractTestCompression;
+import io.airlift.compress.v3.Compressor;
+import io.airlift.compress.v3.Decompressor;
+
+class TestLz4FrameJava
+        extends AbstractTestCompression
+{
+    @Override
+    protected Compressor getCompressor()
+    {
+        return new Lz4FrameJavaCompressor();
+    }
+
+    @Override
+    protected Decompressor getDecompressor()
+    {
+        return new Lz4FrameJavaDecompressor();
+    }
+
+    @Override
+    protected Compressor getVerifyCompressor()
+    {
+        return new Lz4FrameJavaCompressor();
+    }
+
+    @Override
+    protected Decompressor getVerifyDecompressor()
+    {
+        return new Lz4FrameJavaDecompressor();
+    }
+}

--- a/src/test/java/io/airlift/compress/v3/lz4/TestLz4FrameNative.java
+++ b/src/test/java/io/airlift/compress/v3/lz4/TestLz4FrameNative.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.compress.v3.lz4;
+
+import io.airlift.compress.v3.AbstractTestCompression;
+import io.airlift.compress.v3.Compressor;
+import io.airlift.compress.v3.Decompressor;
+
+class TestLz4FrameNative
+        extends AbstractTestCompression
+{
+    @Override
+    protected Compressor getCompressor()
+    {
+        return new Lz4FrameNativeCompressor();
+    }
+
+    @Override
+    protected Decompressor getDecompressor()
+    {
+        return new Lz4FrameNativeDecompressor();
+    }
+
+    @Override
+    protected Compressor getVerifyCompressor()
+    {
+        return new Lz4FrameJavaCompressor();
+    }
+
+    @Override
+    protected Decompressor getVerifyDecompressor()
+    {
+        return new Lz4FrameJavaDecompressor();
+    }
+}

--- a/src/test/java/io/airlift/compress/v3/xxhash/TestXxHash32.java
+++ b/src/test/java/io/airlift/compress/v3/xxhash/TestXxHash32.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.compress.v3.xxhash;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.util.List;
+
+import static java.lang.foreign.ValueLayout.JAVA_BYTE;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestXxHash32
+{
+    // lengths around the 16 byte block boundary and the 4 byte tail boundary
+    private static final List<Integer> LENGTHS = List.of(0, 1, 2, 3, 4, 5, 7, 8, 15, 16, 17, 31, 32, 33, 63, 64, 100, 200, 1024, 4096, 10000);
+    private static final List<Integer> SEEDS = List.of(0, 1, 0x9E3779B1, -1, Integer.MAX_VALUE, Integer.MIN_VALUE);
+
+    private static byte[] data(int length)
+    {
+        byte[] data = new byte[length];
+        for (int i = 0; i < length; i++) {
+            data[i] = (byte) ((i * 31) + 7);
+        }
+        return data;
+    }
+
+    @Test
+    void testKnownVectors()
+    {
+        // reference values from the xxHash specification
+        assertThat(XxHash32JavaHasher.hash(new byte[0], 0, 0, 0)).isEqualTo(0x02CC5D05);
+        assertThat(XxHash32JavaHasher.hash("abc".getBytes(UTF_8), 0, 3, 0)).isEqualTo(0x32D153FF);
+    }
+
+    @Test
+    void testJavaMatchesNative()
+    {
+        if (!XxHash32NativeHasher.isEnabled()) {
+            return;
+        }
+
+        for (int length : LENGTHS) {
+            byte[] data = data(length);
+            for (int seed : SEEDS) {
+                assertThat(XxHash32NativeHasher.hash(data, 0, length, seed))
+                        .describedAs("length=%s seed=%s", length, seed)
+                        .isEqualTo(XxHash32JavaHasher.hash(data, 0, length, seed));
+            }
+        }
+    }
+
+    @Test
+    void testHeapAndNativeSegmentsMatchByteArray()
+    {
+        try (Arena arena = Arena.ofConfined()) {
+            for (int length : LENGTHS) {
+                byte[] data = data(length);
+                int expected = XxHash32JavaHasher.hash(data, 0, length, 0);
+
+                MemorySegment heap = MemorySegment.ofArray(data);
+                MemorySegment nativeSegment = arena.allocateFrom(JAVA_BYTE, data);
+
+                assertThat(XxHash32JavaHasher.hash(heap, 0)).describedAs("heap, length=%s", length).isEqualTo(expected);
+                assertThat(XxHash32JavaHasher.hash(nativeSegment, 0)).describedAs("native, length=%s", length).isEqualTo(expected);
+                assertThat(XxHash32Hasher.hash(heap)).describedAs("hasher heap, length=%s", length).isEqualTo(expected);
+                assertThat(XxHash32Hasher.hash(nativeSegment)).describedAs("hasher native, length=%s", length).isEqualTo(expected);
+            }
+        }
+    }
+
+    @Test
+    void testHashOfSlicedSegmentMatchesRange()
+    {
+        byte[] data = data(1000);
+        MemorySegment segment = MemorySegment.ofArray(data);
+
+        for (int offset : List.of(0, 1, 7, 16, 500)) {
+            for (int length : List.of(0, 1, 15, 16, 17, 400)) {
+                assertThat(XxHash32Hasher.hash(segment.asSlice(offset, length)))
+                        .describedAs("offset=%s length=%s", offset, length)
+                        .isEqualTo(XxHash32Hasher.hash(data, offset, length));
+            }
+        }
+    }
+
+    @Test
+    void testStreamingMatchesOneShot()
+    {
+        for (int length : LENGTHS) {
+            byte[] data = data(length);
+            for (int seed : List.of(0, 42)) {
+                int expected = XxHash32JavaHasher.hash(data, 0, length, seed);
+
+                // feed the input in chunks of varying size to exercise the internal buffer
+                for (int chunkSize : List.of(1, 3, 8, 16, 17, 64)) {
+                    assertThat(digestInChunks(new XxHash32JavaHasher(seed), data, chunkSize))
+                            .describedAs("java length=%s seed=%s chunk=%s", length, seed, chunkSize)
+                            .isEqualTo(expected);
+
+                    if (XxHash32NativeHasher.isEnabled()) {
+                        assertThat(digestInChunks(new XxHash32NativeHasher(seed), data, chunkSize))
+                                .describedAs("native length=%s seed=%s chunk=%s", length, seed, chunkSize)
+                                .isEqualTo(expected);
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    void testStreamingSegmentUpdatesMatchOneShot()
+    {
+        try (Arena arena = Arena.ofConfined()) {
+            for (int length : LENGTHS) {
+                byte[] data = data(length);
+                for (int seed : List.of(0, 42)) {
+                    int expected = XxHash32JavaHasher.hash(data, 0, length, seed);
+
+                    MemorySegment heap = MemorySegment.ofArray(data);
+                    MemorySegment nativeSegment = arena.allocateFrom(JAVA_BYTE, data);
+
+                    for (int chunkSize : List.of(1, 3, 8, 16, 17, 64)) {
+                        assertThat(digestSegmentInChunks(new XxHash32JavaHasher(seed), heap, chunkSize))
+                                .describedAs("java heap length=%s seed=%s chunk=%s", length, seed, chunkSize)
+                                .isEqualTo(expected);
+                        assertThat(digestSegmentInChunks(new XxHash32JavaHasher(seed), nativeSegment, chunkSize))
+                                .describedAs("java native length=%s seed=%s chunk=%s", length, seed, chunkSize)
+                                .isEqualTo(expected);
+
+                        if (XxHash32NativeHasher.isEnabled()) {
+                            assertThat(digestSegmentInChunks(new XxHash32NativeHasher(seed), heap, chunkSize))
+                                    .describedAs("native heap length=%s seed=%s chunk=%s", length, seed, chunkSize)
+                                    .isEqualTo(expected);
+                            assertThat(digestSegmentInChunks(new XxHash32NativeHasher(seed), nativeSegment, chunkSize))
+                                    .describedAs("native native length=%s seed=%s chunk=%s", length, seed, chunkSize)
+                                    .isEqualTo(expected);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private static int digestInChunks(XxHash32Hasher hasher, byte[] data, int chunkSize)
+    {
+        try (hasher) {
+            for (int offset = 0; offset < data.length; offset += chunkSize) {
+                hasher.update(data, offset, Math.min(chunkSize, data.length - offset));
+            }
+            return hasher.digest();
+        }
+    }
+
+    private static int digestSegmentInChunks(XxHash32Hasher hasher, MemorySegment data, int chunkSize)
+    {
+        try (hasher) {
+            for (long offset = 0; offset < data.byteSize(); offset += chunkSize) {
+                hasher.update(data.asSlice(offset, Math.min(chunkSize, data.byteSize() - offset)));
+            }
+            return hasher.digest();
+        }
+    }
+
+    @Test
+    void testReset()
+    {
+        byte[] data = data(100);
+        int expected = XxHash32Hasher.hash(data);
+
+        try (XxHash32Hasher hasher = XxHash32Hasher.create()) {
+            hasher.update(data(37));
+            hasher.reset();
+            hasher.update(data);
+            assertThat(hasher.digest()).isEqualTo(expected);
+
+            hasher.reset(42);
+            hasher.update(data);
+            assertThat(hasher.digest()).isEqualTo(XxHash32Hasher.hash(data, 42));
+        }
+    }
+
+    @Test
+    void testUpdateLE()
+    {
+        byte[] expected = new byte[] {0x78, 0x56, 0x34, 0x12};
+
+        try (XxHash32Hasher hasher = XxHash32Hasher.create()) {
+            hasher.updateLE(0x12345678);
+            assertThat(hasher.digest()).isEqualTo(XxHash32Hasher.hash(expected));
+        }
+    }
+}


### PR DESCRIPTION
Implement support for the standard LZ4 frame format (as produced by the lz4 CLI), distinct from the existing raw LZ4 block format, with both native and pure-Java implementations selected via Lz4FrameCompressor.create() and Lz4FrameDecompressor.create().

The frame container (magic number, frame descriptor with its mandatory xxHash32 header checksum, block framing and end mark) is implemented once in Java in Lz4FrameCompression, and per-block compression is delegated to the raw LZ4 block codec. The two frame codecs therefore differ only in the block codec they use: the Java codec uses the Java block codec, and the native codec uses the native block functions (LZ4_compress_fast / LZ4_decompress_safe).

Doing the framing in Java, rather than binding liblz4's LZ4F_* frame API, avoids depending on how the platform's liblz4 was built: that API uses xxHash32 (LZ4_XXH32_*) internally, and Debian's liblz4.so leaves those symbols undefined, so it fails at runtime on Linux with "undefined symbol: LZ4_XXH32_reset". The raw block functions do not use xxHash, so the native frame codec is unaffected.

Frames are written with independent blocks so they can be decoded block-by-block by either implementation and remain compatible with the lz4 CLI. Decompression decodes all concatenated frames in the input and skips skippable frames, rejecting any other trailing data. Frames using linked blocks or a dictionary are rejected, as are frames with reserved descriptor bits set. Block and content checksums and the advertised content size are verified when present.

Since the frame format requires the 32-bit xxHash variant, which the codebase did not previously have (only xxHash64/xxHash3), XxHash32Hasher is added to the xxhash package alongside the existing hashers, following the same API: static one-shot methods for byte arrays and memory segments, and a streaming hasher obtained from a factory method. Both a pure-Java implementation and a native implementation backed by libxxhash are provided, with the native one used when the library is available.