### PR TITLE
Update library versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.airlift</groupId>
         <artifactId>airbase</artifactId>
-        <version>349</version>
+        <version>395</version>
     </parent>
 
     <groupId>io.airlift</groupId>
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>at.yawk.lz4</groupId>
             <artifactId>lz4-java</artifactId>
-            <version>1.10.2</version>
+            <version>1.11.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>com.github.luben</groupId>
             <artifactId>zstd-jni</artifactId>
-            <version>1.5.6-6</version>
+            <version>1.5.7-11</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -149,7 +149,7 @@
         <dependency>
             <groupId>org.xerial.snappy</groupId>
             <artifactId>snappy-java</artifactId>
-            <version>1.1.10.7</version>
+            <version>1.1.10.8</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/io/airlift/compress/v3/bzip2/CBZip2InputStream.java
+++ b/src/main/java/io/airlift/compress/v3/bzip2/CBZip2InputStream.java
@@ -386,39 +386,29 @@ class CBZip2InputStream
         final int retChar = this.currentChar;
 
         switch (this.currentState) {
-            case EOF:
+            case EOF -> {
                 return END_OF_STREAM; // return -1
+            }
 
-            case NO_PROCESS_STATE:
+            case NO_PROCESS_STATE -> {
                 return END_OF_BLOCK; // return -2
+            }
 
-            case START_BLOCK_STATE:
-                throw new IllegalStateException();
+            case START_BLOCK_STATE -> throw new IllegalStateException();
 
-            case RAND_PART_A_STATE:
-                throw new IllegalStateException();
+            case RAND_PART_A_STATE -> throw new IllegalStateException();
 
-            case RAND_PART_B_STATE:
-                setupRandPartB();
-                break;
+            case RAND_PART_B_STATE -> setupRandPartB();
 
-            case RAND_PART_C_STATE:
-                setupRandPartC();
-                break;
+            case RAND_PART_C_STATE -> setupRandPartC();
 
-            case NO_RAND_PART_A_STATE:
-                throw new IllegalStateException();
+            case NO_RAND_PART_A_STATE -> throw new IllegalStateException();
 
-            case NO_RAND_PART_B_STATE:
-                setupNoRandPartB();
-                break;
+            case NO_RAND_PART_B_STATE -> setupNoRandPartB();
 
-            case NO_RAND_PART_C_STATE:
-                setupNoRandPartC();
-                break;
+            case NO_RAND_PART_C_STATE -> setupNoRandPartC();
 
-            default:
-                throw new IllegalStateException();
+            default -> throw new IllegalStateException();
         }
 
         return retChar;

--- a/src/main/java/io/airlift/compress/v3/bzip2/CBZip2OutputStream.java
+++ b/src/main/java/io/airlift/compress/v3/bzip2/CBZip2OutputStream.java
@@ -512,27 +512,26 @@ class CBZip2OutputStream
             this.crc32.updateCRC(currentCharShadow, runLengthShadow);
 
             switch (runLengthShadow) {
-                case 1:
+                case 1 -> {
                     dataShadow.block[lastShadow + 2] = ch;
                     this.last = lastShadow + 1;
-                    break;
+                }
 
-                case 2:
+                case 2 -> {
                     dataShadow.block[lastShadow + 2] = ch;
                     dataShadow.block[lastShadow + 3] = ch;
                     this.last = lastShadow + 2;
-                    break;
+                }
 
-                case 3: {
+                case 3 -> {
                     final byte[] block = dataShadow.block;
                     block[lastShadow + 2] = ch;
                     block[lastShadow + 3] = ch;
                     block[lastShadow + 4] = ch;
                     this.last = lastShadow + 3;
                 }
-                break;
 
-                default: {
+                default -> {
                     runLengthShadow -= 4;
                     dataShadow.inUse[runLengthShadow] = true;
                     final byte[] block = dataShadow.block;
@@ -543,7 +542,6 @@ class CBZip2OutputStream
                     block[lastShadow + 6] = (byte) runLengthShadow;
                     this.last = lastShadow + 5;
                 }
-                break;
             }
         }
         else {

--- a/src/main/java/io/airlift/compress/v3/snappy/SnappyFramedInputStream.java
+++ b/src/main/java/io/airlift/compress/v3/snappy/SnappyFramedInputStream.java
@@ -241,22 +241,22 @@ public final class SnappyFramedInputStream
         FrameAction frameAction;
         int flag = frameHeader[0] & 0xFF;
         switch (flag) {
-            case SnappyFramed.COMPRESSED_DATA_FLAG:
+            case SnappyFramed.COMPRESSED_DATA_FLAG -> {
                 frameAction = FrameAction.UNCOMPRESS;
                 minLength = 5;
-                break;
-            case SnappyFramed.UNCOMPRESSED_DATA_FLAG:
+            }
+            case SnappyFramed.UNCOMPRESSED_DATA_FLAG -> {
                 frameAction = FrameAction.RAW;
                 minLength = 5;
-                break;
-            case SnappyFramed.STREAM_IDENTIFIER_FLAG:
+            }
+            case SnappyFramed.STREAM_IDENTIFIER_FLAG -> {
                 if (length != 6) {
                     throw new IOException("stream identifier chunk with invalid length: " + length);
                 }
                 frameAction = FrameAction.SKIP;
                 minLength = 6;
-                break;
-            default:
+            }
+            default -> {
                 // Reserved unskippable chunks (chunk types 0x02-0x7f)
                 if (flag <= 0x7f) {
                     throw new IOException("unsupported unskippable chunk: " + Integer.toHexString(flag));
@@ -265,6 +265,7 @@ public final class SnappyFramedInputStream
                 // all that is left is Reserved skippable chunks (chunk types 0x80-0xfe)
                 frameAction = FrameAction.SKIP;
                 minLength = 0;
+            }
         }
 
         if (length < minLength) {

--- a/src/main/java/io/airlift/compress/v3/zstd/DoubleFastBlockCompressor.java
+++ b/src/main/java/io/airlift/compress/v3/zstd/DoubleFastBlockCompressor.java
@@ -215,18 +215,13 @@ class DoubleFastBlockCompressor
 
     private static int hash(Object inputBase, long inputAddress, int bits, int matchSearchLength)
     {
-        switch (matchSearchLength) {
-            case 8:
-                return hash8(UNSAFE.getLong(inputBase, inputAddress), bits);
-            case 7:
-                return hash7(UNSAFE.getLong(inputBase, inputAddress), bits);
-            case 6:
-                return hash6(UNSAFE.getLong(inputBase, inputAddress), bits);
-            case 5:
-                return hash5(UNSAFE.getLong(inputBase, inputAddress), bits);
-            default:
-                return hash4(UNSAFE.getInt(inputBase, inputAddress), bits);
-        }
+        return switch (matchSearchLength) {
+            case 8 -> hash8(UNSAFE.getLong(inputBase, inputAddress), bits);
+            case 7 -> hash7(UNSAFE.getLong(inputBase, inputAddress), bits);
+            case 6 -> hash6(UNSAFE.getLong(inputBase, inputAddress), bits);
+            case 5 -> hash5(UNSAFE.getLong(inputBase, inputAddress), bits);
+            default -> hash4(UNSAFE.getInt(inputBase, inputAddress), bits);
+        };
     }
 
     private static final int PRIME_4_BYTES = 0x9E3779B1;

--- a/src/main/java/io/airlift/compress/v3/zstd/FseCompressionTable.java
+++ b/src/main/java/io/airlift/compress/v3/zstd/FseCompressionTable.java
@@ -93,22 +93,19 @@ class FseCompressionTable
         int total = 0;
         for (int symbol = 0; symbol <= maxSymbol; symbol++) {
             switch (normalizedCounts[symbol]) {
-                case 0:
-                    deltaNumberOfBits[symbol] = ((tableLog + 1) << 16) - tableSize;
-                    break;
-                case -1:
-                case 1:
+                case 0 -> deltaNumberOfBits[symbol] = ((tableLog + 1) << 16) - tableSize;
+                case -1, 1 -> {
                     deltaNumberOfBits[symbol] = (tableLog << 16) - tableSize;
                     deltaFindState[symbol] = total - 1;
                     total++;
-                    break;
-                default:
+                }
+                default -> {
                     int maxBitsOut = tableLog - Util.highestBit(normalizedCounts[symbol] - 1);
                     int minStatePlus = normalizedCounts[symbol] << maxBitsOut;
                     deltaNumberOfBits[symbol] = (maxBitsOut << 16) - minStatePlus;
                     deltaFindState[symbol] = total - normalizedCounts[symbol];
                     total += normalizedCounts[symbol];
-                    break;
+                }
             }
         }
     }

--- a/src/main/java/io/airlift/compress/v3/zstd/SequenceEncoder.java
+++ b/src/main/java/io/airlift/compress/v3/zstd/SequenceEncoder.java
@@ -107,16 +107,14 @@ final class SequenceEncoder
 
         FseCompressionTable literalLengthTable;
         switch (literalsLengthEncodingType) {
-            case SEQUENCE_ENCODING_RLE:
+            case SEQUENCE_ENCODING_RLE -> {
                 UNSAFE.putByte(outputBase, output, sequences.literalLengthCodes[0]);
                 output++;
                 workspace.literalLengthTable.initializeRleTable(maxSymbol);
                 literalLengthTable = workspace.literalLengthTable;
-                break;
-            case SEQUENCE_ENCODING_BASIC:
-                literalLengthTable = DEFAULT_LITERAL_LENGTHS_TABLE;
-                break;
-            case SEQUENCE_ENCODING_COMPRESSED:
+            }
+            case SEQUENCE_ENCODING_BASIC -> literalLengthTable = DEFAULT_LITERAL_LENGTHS_TABLE;
+            case SEQUENCE_ENCODING_COMPRESSED -> {
                 output += buildCompressionTable(
                         workspace.literalLengthTable,
                         outputBase,
@@ -129,9 +127,8 @@ final class SequenceEncoder
                         maxSymbol,
                         workspace.normalizedCounts);
                 literalLengthTable = workspace.literalLengthTable;
-                break;
-            default:
-                throw new UnsupportedOperationException("not yet implemented");
+            }
+            default -> throw new UnsupportedOperationException("not yet implemented");
         }
 
         // offsets
@@ -146,16 +143,14 @@ final class SequenceEncoder
 
         FseCompressionTable offsetCodeTable;
         switch (offsetEncodingType) {
-            case SEQUENCE_ENCODING_RLE:
+            case SEQUENCE_ENCODING_RLE -> {
                 UNSAFE.putByte(outputBase, output, sequences.offsetCodes[0]);
                 output++;
                 workspace.offsetCodeTable.initializeRleTable(maxSymbol);
                 offsetCodeTable = workspace.offsetCodeTable;
-                break;
-            case SEQUENCE_ENCODING_BASIC:
-                offsetCodeTable = DEFAULT_OFFSETS_TABLE;
-                break;
-            case SEQUENCE_ENCODING_COMPRESSED:
+            }
+            case SEQUENCE_ENCODING_BASIC -> offsetCodeTable = DEFAULT_OFFSETS_TABLE;
+            case SEQUENCE_ENCODING_COMPRESSED -> {
                 output += buildCompressionTable(
                         workspace.offsetCodeTable,
                         outputBase,
@@ -168,9 +163,8 @@ final class SequenceEncoder
                         maxSymbol,
                         workspace.normalizedCounts);
                 offsetCodeTable = workspace.offsetCodeTable;
-                break;
-            default:
-                throw new UnsupportedOperationException("not yet implemented");
+            }
+            default -> throw new UnsupportedOperationException("not yet implemented");
         }
 
         // match lengths
@@ -182,16 +176,14 @@ final class SequenceEncoder
 
         FseCompressionTable matchLengthTable;
         switch (matchLengthEncodingType) {
-            case SEQUENCE_ENCODING_RLE:
+            case SEQUENCE_ENCODING_RLE -> {
                 UNSAFE.putByte(outputBase, output, sequences.matchLengthCodes[0]);
                 output++;
                 workspace.matchLengthTable.initializeRleTable(maxSymbol);
                 matchLengthTable = workspace.matchLengthTable;
-                break;
-            case SEQUENCE_ENCODING_BASIC:
-                matchLengthTable = DEFAULT_MATCH_LENGTHS_TABLE;
-                break;
-            case SEQUENCE_ENCODING_COMPRESSED:
+            }
+            case SEQUENCE_ENCODING_BASIC -> matchLengthTable = DEFAULT_MATCH_LENGTHS_TABLE;
+            case SEQUENCE_ENCODING_COMPRESSED -> {
                 output += buildCompressionTable(
                         workspace.matchLengthTable,
                         outputBase,
@@ -204,9 +196,8 @@ final class SequenceEncoder
                         maxSymbol,
                         workspace.normalizedCounts);
                 matchLengthTable = workspace.matchLengthTable;
-                break;
-            default:
-                throw new UnsupportedOperationException("not yet implemented");
+            }
+            default -> throw new UnsupportedOperationException("not yet implemented");
         }
 
         // flags

--- a/src/main/java/io/airlift/compress/v3/zstd/ZstdFrameCompressor.java
+++ b/src/main/java/io/airlift/compress/v3/zstd/ZstdFrameCompressor.java
@@ -100,21 +100,20 @@ final class ZstdFrameCompressor
         }
 
         switch (contentSizeDescriptor) {
-            case 0:
+            case 0 -> {
                 if (singleSegment) {
                     UNSAFE.putByte(outputBase, output++, (byte) inputSize);
                 }
-                break;
-            case 1:
+            }
+            case 1 -> {
                 UNSAFE.putShort(outputBase, output, (short) (inputSize - 256));
                 output += SIZE_OF_SHORT;
-                break;
-            case 2:
+            }
+            case 2 -> {
                 UNSAFE.putInt(outputBase, output, inputSize);
                 output += SIZE_OF_INT;
-                break;
-            default:
-                throw new AssertionError();
+            }
+            default -> throw new AssertionError();
         }
 
         return (int) (output - outputAddress);
@@ -358,24 +357,21 @@ final class ZstdFrameCompressor
 
         // Build header
         switch (headerSize) {
-            case 3: { // 2 - 2 - 10 - 10
+            case 3 -> { // 2 - 2 - 10 - 10
                 int header = encodingType | ((singleStream ? 0 : 1) << 2) | (literalsSize << 4) | (totalSize << 14);
                 put24BitLittleEndian(outputBase, outputAddress, header);
-                break;
             }
-            case 4: { // 2 - 2 - 14 - 14
+            case 4 -> { // 2 - 2 - 14 - 14
                 int header = encodingType | (2 << 2) | (literalsSize << 4) | (totalSize << 18);
                 UNSAFE.putInt(outputBase, outputAddress, header);
-                break;
             }
-            case 5: { // 2 - 2 - 18 - 18
+            case 5 -> { // 2 - 2 - 18 - 18
                 int header = encodingType | (3 << 2) | (literalsSize << 4) | (totalSize << 22);
                 UNSAFE.putInt(outputBase, outputAddress, header);
                 UNSAFE.putByte(outputBase, outputAddress + SIZE_OF_INT, (byte) (totalSize >>> 10));
-                break;
             }
-            default:  // not possible : headerSize is {3,4,5}
-                throw new IllegalStateException();
+            default ->  // not possible : headerSize is {3,4,5}
+                    throw new IllegalStateException();
         }
 
         return headerSize + totalSize;
@@ -386,17 +382,14 @@ final class ZstdFrameCompressor
         int headerSize = 1 + (inputSize > 31 ? 1 : 0) + (inputSize > 4095 ? 1 : 0);
 
         switch (headerSize) {
-            case 1: // 2 - 1 - 5
-                UNSAFE.putByte(outputBase, outputAddress, (byte) (RLE_LITERALS_BLOCK | (inputSize << 3)));
-                break;
-            case 2: // 2 - 2 - 12
-                UNSAFE.putShort(outputBase, outputAddress, (short) (RLE_LITERALS_BLOCK | (1 << 2) | (inputSize << 4)));
-                break;
-            case 3: // 2 - 2 - 20
-                UNSAFE.putInt(outputBase, outputAddress, RLE_LITERALS_BLOCK | 3 << 2 | inputSize << 4);
-                break;
-            default:   // impossible. headerSize is {1,2,3}
-                throw new IllegalStateException();
+            case 1 -> // 2 - 1 - 5
+                    UNSAFE.putByte(outputBase, outputAddress, (byte) (RLE_LITERALS_BLOCK | (inputSize << 3)));
+            case 2 -> // 2 - 2 - 12
+                    UNSAFE.putShort(outputBase, outputAddress, (short) (RLE_LITERALS_BLOCK | (1 << 2) | (inputSize << 4)));
+            case 3 -> // 2 - 2 - 20
+                    UNSAFE.putInt(outputBase, outputAddress, RLE_LITERALS_BLOCK | 3 << 2 | inputSize << 4);
+            default -> // impossible. headerSize is {1,2,3}
+                    throw new IllegalStateException();
         }
 
         UNSAFE.putByte(outputBase, outputAddress + headerSize, UNSAFE.getByte(inputBase, inputAddress));
@@ -424,17 +417,10 @@ final class ZstdFrameCompressor
         checkArgument(inputSize + headerSize <= outputSize, "Output buffer too small");
 
         switch (headerSize) {
-            case 1:
-                UNSAFE.putByte(outputBase, outputAddress, (byte) (RAW_LITERALS_BLOCK | (inputSize << 3)));
-                break;
-            case 2:
-                UNSAFE.putShort(outputBase, outputAddress, (short) (RAW_LITERALS_BLOCK | (1 << 2) | (inputSize << 4)));
-                break;
-            case 3:
-                put24BitLittleEndian(outputBase, outputAddress, RAW_LITERALS_BLOCK | (3 << 2) | (inputSize << 4));
-                break;
-            default:
-                throw new AssertionError();
+            case 1 -> UNSAFE.putByte(outputBase, outputAddress, (byte) (RAW_LITERALS_BLOCK | (inputSize << 3)));
+            case 2 -> UNSAFE.putShort(outputBase, outputAddress, (short) (RAW_LITERALS_BLOCK | (1 << 2) | (inputSize << 4)));
+            case 3 -> put24BitLittleEndian(outputBase, outputAddress, RAW_LITERALS_BLOCK | (3 << 2) | (inputSize << 4));
+            default -> throw new AssertionError();
         }
 
         // TODO: ensure this test is correct

--- a/src/main/java/io/airlift/compress/v3/zstd/ZstdFrameDecompressor.java
+++ b/src/main/java/io/airlift/compress/v3/zstd/ZstdFrameDecompressor.java
@@ -169,23 +169,22 @@ class ZstdFrameDecompressor
 
                 int decodedSize;
                 switch (blockType) {
-                    case RAW_BLOCK:
+                    case RAW_BLOCK -> {
                         verify(input + blockSize <= inputLimit, input, "Not enough input bytes");
                         decodedSize = decodeRawBlock(inputBase, input, blockSize, outputBase, output, outputLimit);
                         input += blockSize;
-                        break;
-                    case RLE_BLOCK:
+                    }
+                    case RLE_BLOCK -> {
                         verify(input + 1 <= inputLimit, input, "Not enough input bytes");
                         decodedSize = decodeRleBlock(blockSize, inputBase, input, outputBase, output, outputLimit);
                         input += 1;
-                        break;
-                    case COMPRESSED_BLOCK:
+                    }
+                    case COMPRESSED_BLOCK -> {
                         verify(input + blockSize <= inputLimit, input, "Not enough input bytes");
                         decodedSize = decodeCompressedBlock(inputBase, input, blockSize, outputBase, output, outputLimit, frameHeader.windowSize, outputAddress);
                         input += blockSize;
-                        break;
-                    default:
-                        throw fail(input, "Invalid block type");
+                    }
+                    default -> throw fail(input, "Invalid block type");
                 }
 
                 output += decodedSize;
@@ -610,7 +609,7 @@ class ZstdFrameDecompressor
     private long computeMatchLengthTable(int matchLengthType, Object inputBase, long input, long inputLimit)
     {
         switch (matchLengthType) {
-            case SEQUENCE_ENCODING_RLE:
+            case SEQUENCE_ENCODING_RLE -> {
                 verify(input < inputLimit, input, "Not enough input bytes");
 
                 byte value = UNSAFE.getByte(inputBase, input++);
@@ -618,19 +617,14 @@ class ZstdFrameDecompressor
 
                 FseTableReader.initializeRleTable(matchLengthTable, value);
                 currentMatchLengthTable = matchLengthTable;
-                break;
-            case SEQUENCE_ENCODING_BASIC:
-                currentMatchLengthTable = DEFAULT_MATCH_LENGTH_TABLE;
-                break;
-            case SEQUENCE_ENCODING_REPEAT:
-                verify(currentMatchLengthTable != null, input, "Expected match length table to be present");
-                break;
-            case SEQUENCE_ENCODING_COMPRESSED:
+            }
+            case SEQUENCE_ENCODING_BASIC -> currentMatchLengthTable = DEFAULT_MATCH_LENGTH_TABLE;
+            case SEQUENCE_ENCODING_REPEAT -> verify(currentMatchLengthTable != null, input, "Expected match length table to be present");
+            case SEQUENCE_ENCODING_COMPRESSED -> {
                 input += fse.readFseTable(matchLengthTable, inputBase, input, inputLimit, MAX_MATCH_LENGTH_SYMBOL, MATCH_LENGTH_TABLE_LOG);
                 currentMatchLengthTable = matchLengthTable;
-                break;
-            default:
-                throw fail(input, "Invalid match length encoding type");
+            }
+            default -> throw fail(input, "Invalid match length encoding type");
         }
         return input;
     }
@@ -638,7 +632,7 @@ class ZstdFrameDecompressor
     private long computeOffsetsTable(int offsetCodesType, Object inputBase, long input, long inputLimit)
     {
         switch (offsetCodesType) {
-            case SEQUENCE_ENCODING_RLE:
+            case SEQUENCE_ENCODING_RLE -> {
                 verify(input < inputLimit, input, "Not enough input bytes");
 
                 byte value = UNSAFE.getByte(inputBase, input++);
@@ -646,19 +640,14 @@ class ZstdFrameDecompressor
 
                 FseTableReader.initializeRleTable(offsetCodesTable, value);
                 currentOffsetCodesTable = offsetCodesTable;
-                break;
-            case SEQUENCE_ENCODING_BASIC:
-                currentOffsetCodesTable = DEFAULT_OFFSET_CODES_TABLE;
-                break;
-            case SEQUENCE_ENCODING_REPEAT:
-                verify(currentOffsetCodesTable != null, input, "Expected match length table to be present");
-                break;
-            case SEQUENCE_ENCODING_COMPRESSED:
+            }
+            case SEQUENCE_ENCODING_BASIC -> currentOffsetCodesTable = DEFAULT_OFFSET_CODES_TABLE;
+            case SEQUENCE_ENCODING_REPEAT -> verify(currentOffsetCodesTable != null, input, "Expected match length table to be present");
+            case SEQUENCE_ENCODING_COMPRESSED -> {
                 input += fse.readFseTable(offsetCodesTable, inputBase, input, inputLimit, DEFAULT_MAX_OFFSET_CODE_SYMBOL, OFFSET_TABLE_LOG);
                 currentOffsetCodesTable = offsetCodesTable;
-                break;
-            default:
-                throw fail(input, "Invalid offset code encoding type");
+            }
+            default -> throw fail(input, "Invalid offset code encoding type");
         }
         return input;
     }
@@ -666,7 +655,7 @@ class ZstdFrameDecompressor
     private long computeLiteralsTable(int literalsLengthType, Object inputBase, long input, long inputLimit)
     {
         switch (literalsLengthType) {
-            case SEQUENCE_ENCODING_RLE:
+            case SEQUENCE_ENCODING_RLE -> {
                 verify(input < inputLimit, input, "Not enough input bytes");
 
                 byte value = UNSAFE.getByte(inputBase, input++);
@@ -674,19 +663,14 @@ class ZstdFrameDecompressor
 
                 FseTableReader.initializeRleTable(literalsLengthTable, value);
                 currentLiteralsLengthTable = literalsLengthTable;
-                break;
-            case SEQUENCE_ENCODING_BASIC:
-                currentLiteralsLengthTable = DEFAULT_LITERALS_LENGTH_TABLE;
-                break;
-            case SEQUENCE_ENCODING_REPEAT:
-                verify(currentLiteralsLengthTable != null, input, "Expected match length table to be present");
-                break;
-            case SEQUENCE_ENCODING_COMPRESSED:
+            }
+            case SEQUENCE_ENCODING_BASIC -> currentLiteralsLengthTable = DEFAULT_LITERALS_LENGTH_TABLE;
+            case SEQUENCE_ENCODING_REPEAT -> verify(currentLiteralsLengthTable != null, input, "Expected match length table to be present");
+            case SEQUENCE_ENCODING_COMPRESSED -> {
                 input += fse.readFseTable(literalsLengthTable, inputBase, input, inputLimit, MAX_LITERALS_LENGTH_SYMBOL, LITERAL_LENGTH_TABLE_LOG);
                 currentLiteralsLengthTable = literalsLengthTable;
-                break;
-            default:
-                throw fail(input, "Invalid literals length encoding type");
+            }
+            default -> throw fail(input, "Invalid literals length encoding type");
         }
         return input;
     }
@@ -796,23 +780,21 @@ class ZstdFrameDecompressor
 
         int type = (UNSAFE.getByte(inputBase, input) >> 2) & 0b11;
         switch (type) {
-            case 0:
-            case 2:
+            case 0, 2 -> {
                 outputSize = (UNSAFE.getByte(inputBase, input) & 0xFF) >>> 3;
                 input++;
-                break;
-            case 1:
+            }
+            case 1 -> {
                 outputSize = (UNSAFE.getShort(inputBase, input) & 0xFFFF) >>> 4;
                 input += 2;
-                break;
-            case 3:
+            }
+            case 3 -> {
                 // we need at least 4 bytes (3 for the header, 1 for the payload)
                 verify(blockSize >= SIZE_OF_INT, input, "Not enough input bytes");
                 outputSize = (UNSAFE.getInt(inputBase, input) & 0xFF_FFFF) >>> 4;
                 input += 3;
-                break;
-            default:
-                throw fail(input, "Invalid RLE literals header encoding type");
+            }
+            default -> throw fail(input, "Invalid RLE literals header encoding type");
         }
 
         verify(outputSize <= MAX_BLOCK_SIZE, input, "Output exceeds maximum block size");
@@ -834,25 +816,23 @@ class ZstdFrameDecompressor
 
         int literalSize;
         switch (type) {
-            case 0:
-            case 2:
+            case 0, 2 -> {
                 literalSize = (UNSAFE.getByte(inputBase, input) & 0xFF) >>> 3;
                 input++;
-                break;
-            case 1:
+            }
+            case 1 -> {
                 literalSize = (UNSAFE.getShort(inputBase, input) & 0xFFFF) >>> 4;
                 input += 2;
-                break;
-            case 3:
+            }
+            case 3 -> {
                 // read 3 little-endian bytes
                 int header = ((UNSAFE.getByte(inputBase, input) & 0xFF) |
                         ((UNSAFE.getShort(inputBase, input + 1) & 0xFFFF) << 8));
 
                 literalSize = header >>> 4;
                 input += 3;
-                break;
-            default:
-                throw fail(input, "Invalid raw literals header encoding type");
+            }
+            default -> throw fail(input, "Invalid raw literals header encoding type");
         }
 
         verify(input + literalSize <= inputLimit, input, "Not enough input bytes");
@@ -908,43 +888,45 @@ class ZstdFrameDecompressor
         // decode dictionary id
         long dictionaryId = -1;
         switch (dictionaryDescriptor) {
-            case 1:
+            case 1 -> {
                 dictionaryId = UNSAFE.getByte(inputBase, input) & 0xFF;
                 input += SIZE_OF_BYTE;
-                break;
-            case 2:
+            }
+            case 2 -> {
                 dictionaryId = UNSAFE.getShort(inputBase, input) & 0xFFFF;
                 input += SIZE_OF_SHORT;
-                break;
-            case 3:
+            }
+            case 3 -> {
                 dictionaryId = UNSAFE.getInt(inputBase, input) & 0xFFFF_FFFFL;
                 input += SIZE_OF_INT;
-                break;
+            }
+            default -> {}
         }
         verify(dictionaryId == -1, input, "Custom dictionaries not supported");
 
         // decode content size
         long contentSize = -1;
         switch (contentSizeDescriptor) {
-            case 0:
+            case 0 -> {
                 if (singleSegment) {
                     contentSize = UNSAFE.getByte(inputBase, input) & 0xFF;
                     input += SIZE_OF_BYTE;
                 }
-                break;
-            case 1:
+            }
+            case 1 -> {
                 contentSize = UNSAFE.getShort(inputBase, input) & 0xFFFF;
                 contentSize += 256;
                 input += SIZE_OF_SHORT;
-                break;
-            case 2:
+            }
+            case 2 -> {
                 contentSize = UNSAFE.getInt(inputBase, input) & 0xFFFF_FFFFL;
                 input += SIZE_OF_INT;
-                break;
-            case 3:
+            }
+            case 3 -> {
                 contentSize = UNSAFE.getLong(inputBase, input);
                 input += SIZE_OF_LONG;
-                break;
+            }
+            default -> throw new AssertionError();
         }
 
         boolean hasChecksum = (frameHeaderDescriptor & 0b100) != 0;

--- a/src/main/java/io/airlift/compress/v3/zstd/ZstdIncrementalFrameDecompressor.java
+++ b/src/main/java/io/airlift/compress/v3/zstd/ZstdIncrementalFrameDecompressor.java
@@ -207,7 +207,7 @@ public class ZstdIncrementalFrameDecompressor
 
                 int decodedSize;
                 switch (blockType) {
-                    case RAW_BLOCK: {
+                    case RAW_BLOCK -> {
                         if (inputLimit - input < blockSize) {
                             inputRequired(inputAddress, outputOffset, input, output, blockSize);
                             return;
@@ -215,9 +215,8 @@ public class ZstdIncrementalFrameDecompressor
                         verify(windowLimit - windowPosition >= blockSize, input, "window buffer is too small");
                         decodedSize = decodeRawBlock(inputBase, input, blockSize, windowBase, windowPosition, windowLimit);
                         input += blockSize;
-                        break;
                     }
-                    case RLE_BLOCK: {
+                    case RLE_BLOCK -> {
                         if (inputLimit - input < 1) {
                             inputRequired(inputAddress, outputOffset, input, output, 1);
                             return;
@@ -225,9 +224,8 @@ public class ZstdIncrementalFrameDecompressor
                         verify(windowLimit - windowPosition >= blockSize, input, "window buffer is too small");
                         decodedSize = decodeRleBlock(blockSize, inputBase, input, windowBase, windowPosition, windowLimit);
                         input += 1;
-                        break;
                     }
-                    case COMPRESSED_BLOCK: {
+                    case COMPRESSED_BLOCK -> {
                         if (inputLimit - input < blockSize) {
                             inputRequired(inputAddress, outputOffset, input, output, blockSize);
                             return;
@@ -235,10 +233,8 @@ public class ZstdIncrementalFrameDecompressor
                         verify(windowLimit - windowPosition >= MAX_BLOCK_SIZE, input, "window buffer is too small");
                         decodedSize = frameDecompressor.decodeCompressedBlock(inputBase, input, blockSize, windowBase, windowPosition, windowLimit, frameHeader.windowSize, windowAddress);
                         input += blockSize;
-                        break;
                     }
-                    default:
-                        throw fail(input, "Invalid block type");
+                    default -> throw fail(input, "Invalid block type");
                 }
                 windowPosition += decodedSize;
                 if (lastBlock) {


### PR DESCRIPTION
## Summary

- Update Airbase from 349 to 395.
- Update lz4-java to 1.11.1, zstd-jni to 1.5.7-11, and snappy-java to 1.1.10.8.
- Adopt the enhanced switch syntax required by the current Airbase checks.

## Impact

This keeps the build and compression reference libraries on their latest stable releases without changing compression behavior.
